### PR TITLE
[auto] P3 margin-inflation cost-critic interface (epistemic k·σ → RiskInflationCritic)

### DIFF
--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -20,6 +20,16 @@
 - **Lean**: 문서화된 placeholder 로 두되 hard-code 금지 (config), P5 measured OOD spread 로 calibrate. Q-008 (`k`) 와 함께 sweep.
 - **다음 action**: P5 uncertainty-calibration harness (epi↑ on OOD) 확보 시 `σ²_ref` + `k` 동시 set → resolve 시 D-MMM. ref: [`epistemic_channel_bev_rendering.md`](epistemic_channel_bev_rendering.md) §2.3/§5.
 
+## Q-008 — 2026-06-12 — `[uncertainty]` epistemic-margin gain `k`: 어떻게 set 하나 (variance→safety routing)
+
+- **Question**: ensemble `σ` 를 안전 margin 으로 라우팅할 때 (additive `λσ²` 아닌 margin-inflation) margin = `k·σ` 의 gain `k` (m / unit σ) 를 어떻게 정하나. Stochastic-MPPI 는 chance-constraint level `ε` 에서 유도하나 우리는 `ε` target 도 정량 harness 도 P5 전엔 없음.
+- **Trade-off**:
+  - **measured near-miss 로 sweep (P5)**: 의미 있는 값, 그러나 eval harness 전엔 측정 불가
+  - **hand-pick 임시값**: 즉시 진행, 그러나 임의 스케일 → margin 이 의미 없는 보수성
+- **Lean**: config 로 노출 (`k_margin_per_sigma`), **default `0.0` ⇒ exact-baseline no-op** 로 plumbing 먼저 landing, P5 near-miss metric 으로 sweep. `σ²_ref`(Q-009) 와 형제 knob — 함께 calibrate.
+- **다음 action**: (1) routing **resolved** this cycle — `k·σ` 가 standalone `RiskInflationCritic` (overload `CostCritic` 아님) 으로 진입, mask-gated/tighten-only/bounded by `inflation_radius`. → D-013 으로 승격 예정 (decisions.md 가 #52 prepend 와 충돌 안 할 때). (2) `k` **값** 은 P5 harness 확보 시 set → resolve 시 D-MMM. ref: [`margin_inflation_cost_critic_interface.md`](margin_inflation_cost_critic_interface.md), [`residual_in_rollout_reference.md`](residual_in_rollout_reference.md) §Axis-2.
+- **Status**: partially-answered (routing → D-013 pending; `k` value open for P5)
+
 ## Q-007 — 2026-05-31 — `[arch]` residual 의 nominal model: analytic unicycle vs 학습 LNN
 
 - **Question**: C1 ensemble residual 의 nominal 항을 analytic unicycle (현재 bootstrap) 로 둘지, STRIDE-style 학습 LNN 으로 둘지.

--- a/docs/margin_inflation_cost_critic_interface.md
+++ b/docs/margin_inflation_cost_critic_interface.md
@@ -1,0 +1,164 @@
+# Margin-Inflation Cost-Critic Interface — where `k·σ` enters nav2_mppi
+
+_Phase P3 · 2026-06-19 · specs the **exact point in the nav2_mppi cost** where the
+epistemic channel inflates the obstacle margin, closing the routing half of Q-008.
+Interface/design only — no code dependency on the (merge-blocked) ensemble. This is
+the consumer end of the stack-tensor contract: the epistemic channel
+([`epistemic_channel_bev_rendering.md`](epistemic_channel_bev_rendering.md), idx 3 of
+[`multi_channel_risk_bev_stack.md`](multi_channel_risk_bev_stack.md) §4) feeds the
+margin gain `k·σ` specced here; the rollout-wiring that produces `σ` is
+[`residual_in_rollout_reference.md`](residual_in_rollout_reference.md) Axis 2.
+See [`decisions.md`](decisions.md) D-009/D-012, [`deliberations.md`](deliberations.md) Q-008.
+(The §1 critic-placement decision is promoted to `decisions.md` as **D-013** by a
+follow-up cycle once that file is conflict-free — open PR #52 currently holds the D-012
+prepend, so this cycle records the decision here + in Q-008 to avoid the D-011 conflict trap.)_
+
+## 0. What this doc closes
+
+Three upstream docs all defer the same one sentence to "the critic-interface doc":
+
+- residual_in_rollout_reference.md §Axis-2 picks **margin inflation** (option 2) over
+  additive `λσ²` as the variance→safety route, but leaves *where in nav2_mppi* unspecified.
+- epistemic_channel_bev_rendering.md §3 produces a `σ_raw` raster "in real σ units
+  (`k·σ` in meters)" for "the margin-inflation critic" — but does not define that critic.
+- multi_channel_risk_bev_stack.md §4 routes row 3 (epistemic) to "margin inflation `k·σ`
+  → TODO `37cc5d39-…-8171`" — this doc.
+
+The genuinely-new decision here: **which nav2_mppi cost term consumes the epistemic
+channel, and how `k·σ` changes its output**, given the *actual* critic stack in
+`config/nav2_mppi_params.yaml`.
+
+## 1. The actual obstacle terms in our nav2_mppi config
+
+Two places encode obstacle distance in the live config (`nav2_mppi_params.yaml`,
+mirrored in `nav2_jackal_params.yaml` / `nav2_outdoor_params.yaml`):
+
+| Where | Mechanism | Margin knob today | Per-trajectory-point? |
+|---|---|---|---|
+| `CostCritic` (MPPI critic) | looks up the **inflated costmap cost** at each sampled trajectory point; `near_collision_cost: 253`, `critical_cost: 300.0`, `collision_cost: 1e6` | thresholds on the costmap cost value | **yes** — scores every rollout |
+| `local_costmap` → `inflation_layer` | pre-inflates obstacles into a cost field (`inflation_radius: 0.4`, `cost_scaling_factor`) | `inflation_radius` (global, static) | no — a map-wide preprocess |
+
+The costmap inflation is a **global, pre-rollout** transform: it cannot vary the margin
+per cell by an epistemic field that is itself recomputed each control step from the
+rollouts. `CostCritic` is the **only** term that (a) runs inside the per-rollout scoring
+loop and (b) already consumes a spatial field at trajectory-point granularity. So the
+epistemic margin must enter at the **critic** level, not the costmap-layer level.
+
+> **Decision (→ D-013, pending decisions.md promotion): introduce a standalone
+> `RiskInflationCritic`, do not overload `CostCritic`.** A separate critic keeps the baseline obstacle term untouched (clean
+> ablation: disable the new critic → exact baseline), gives the epistemic margin its
+> own `cost_weight` independent of `CostCritic`'s 3.81, and isolates the P5 `k`-sweep to
+> one plugin. Overloading `CostCritic` would entangle two gains in one weight and make
+> "MPPI without representation-aware margin" un-measurable — fatal for the P5 ablation
+> that is the whole point of the project.
+
+## 2. The margin-inflation rule
+
+The epistemic channel supplies, per ego-frame cell, a real-unit disagreement `σ(x,y)`
+(the `sigma_raw` raster from epistemic §2.3, *not* the `[0,1]` form — margins are meters).
+For a sampled trajectory point at ego-frame position `(x,y)`:
+
+```
+σ_pt      = sample(sigma_raw, x, y)          # NN-lookup into the epistemic raster
+d_eff     = d_obstacle(x,y) − k · σ_pt       # effective clearance, shrunk by disagreement
+cost_pt   = barrier(d_eff)                   # same barrier shape CostCritic uses
+```
+
+Equivalently, since `CostCritic` works in costmap-cost space rather than metric
+clearance, the implementation **inflates the effective obstacle footprint** seen by the
+critic by `k·σ_pt` meters before the cost lookup — i.e. a trajectory point is treated as
+if obstacles were `k·σ_pt` closer than they metrically are. High disagreement ⇒ larger
+effective footprint ⇒ the planner backs off **exactly where the dynamics model is least
+trusted**, which is the Stochastic-MPPI mechanism (residual_in_rollout_reference.md §Axis-2)
+expressed in our critic stack.
+
+Key properties this rule must preserve:
+
+- **Inflation only ever tightens, never loosens.** `k ≥ 0`, `σ ≥ 0` ⇒ `d_eff ≤ d_obstacle`.
+  A representation channel must not be able to *reduce* a margin and drive into an obstacle.
+- **Bounded.** Clamp `k·σ_pt ≤ Δ_max` (config) so a pathological σ spike cannot inflate
+  the footprint to "everything is a collision" and freeze the robot. `Δ_max` defaults to
+  the costmap `inflation_radius` (0.4 m) — never inflate beyond the existing safety layer.
+- **Margin is additive in clearance, not multiplicative in cost.** This is the
+  residual_in_rollout_reference.md §Axis-2 choice (option 2, not option 1's `cost += λσ²`):
+  it changes the *constraint geometry*, so the effect is interpretable in meters and
+  composes with `CostCritic`'s existing thresholds instead of fighting its weight.
+
+## 3. Unobserved cells — no inflation (mask-gated)
+
+Per the stack-tensor contract (multi_channel_risk_bev_stack.md §2) the epistemic row
+travels with an observability plane (mask idx 3). The critic **must** gate on it:
+
+```
+σ_pt_effective = mask[EPISTEMIC, x, y] ? σ_pt : 0.0
+```
+
+- mask `0` (unevaluated — no rollout sample landed in that cell) ⇒ **no inflation**.
+  This matches epistemic §3: "the planner isn't considering trajectories there, so
+  there's nothing to make conservative." The *occupancy* safety of unseen cells is the
+  costmap's job (and the 미관측-prior question O-1 in the stack doc), **not** this critic's.
+- The critic must never read an unobserved cell as `σ=high` (would invent phantom margins
+  on every cell a rollout missed) nor as a confident `σ=0` smuggled through — the mask is
+  the only correct disambiguator, which is exactly why the stack doc carries it explicitly
+  rather than as a NaN sentinel.
+
+## 4. The `k` knob (Q-008) — config, never a literal
+
+`k` (meters of margin per unit σ) is the gain this doc routes but **does not set** — its
+value is Q-008, deferred to P5 because it must be tuned against a measured near-miss /
+success-rate metric we do not yet have. The interface obligation is only that `k` (and
+`Δ_max`) are **plugin parameters**, defaulted and documented, never hard-coded:
+
+```yaml
+RiskInflationCritic:
+  enabled: true
+  cost_power: 1
+  cost_weight: 3.81          # start == CostCritic; independent so P5 can sweep it
+  k_margin_per_sigma: 0.0    # Q-008: DEFAULT 0.0 ⇒ exact-baseline behavior until tuned
+  max_inflation_m: 0.4       # == local_costmap inflation_radius; hard upper clamp
+  epistemic_channel_index: 3 # RiskChannel.EPISTEMIC (stack-tensor enum, never guessed)
+  trajectory_point_step: 2   # match CostCritic so the two score the same points
+```
+
+**`k_margin_per_sigma` defaults to `0.0`.** This is deliberate: shipping the critic with
+`k=0` makes it a no-op identical to baseline, so the *plumbing* can land and be smoke-
+tested before any tuned gain exists — and the P5 ablation flips a single number rather
+than wiring a new critic under deadline. (Same discipline as epistemic §2.2 weights and
+`σ²_ref`: ship a documented default, never a silent literal.)
+
+## 5. Epistemic vs aleatoric routing stays split here too
+
+This critic consumes **only** the epistemic row (idx 3). The aleatoric row (idx 4) routes
+to a *different* term — chance-constraint / CVaR tightening (stack doc §4, aleatoric doc
+§4) — because irreducible noise does not shrink with data and so should not feed a
+back-off-where-ignorant margin. Wiring both rows into one margin would re-collapse the
+epi/ale split that is P3's reason for being. The aleatoric→risk-sensitive term is the
+sibling spec (separate TODO); this doc owns the epistemic→margin route only.
+
+## 6. Acceptance / what "done" looks like (when code unblocks)
+
+The implementing PR (post-#44, post-ensemble, post-stack-render) should satisfy:
+
+1. A `RiskInflationCritic` nav2_mppi critic plugin registered alongside the existing 8,
+   **off by default via `k=0`** so adding it to the `critics:` list is a no-op until tuned.
+2. It samples `sigma_raw` + `mask` (epistemic channel, idx 3) at each trajectory point,
+   applies §2's bounded, tighten-only, mask-gated inflation, and adds the resulting cost.
+3. `k_margin_per_sigma`, `max_inflation_m`, `epistemic_channel_index`, `trajectory_point_step`
+   are all config (§4) — no literals; `k`/`Δ_max` documented as Q-008 / safety clamps.
+4. Disabling the critic (or `k=0`) reproduces the exact baseline trajectory — the
+   ablation invariant.
+5. `qual:` metric pre-P5; the quantitative gate is the P5 near-miss-rate sweep over `k`
+   (Q-008) once the eval harness lands — lower near-miss at fixed success/time-to-goal is
+   the win condition.
+
+## 7. Open questions raised (→ deliberations)
+
+- **Q-008 (the `k` value) stays open** — this doc resolves *where* `k·σ` enters (routing →
+  the `RiskInflationCritic` placement decision, D-013 pending) but not *what k is*; that is
+  a P5 metric-driven sweep. Updated Q-008's note to reflect the routing half is now closed.
+- **Footprint-inflation vs clearance-subtraction equivalence.** §2 gives two framings
+  (subtract `k·σ` from clearance, or inflate the effective footprint by `k·σ`). They are
+  equal for a circular footprint but diverge once `CostCritic.consider_footprint: true`
+  (currently `false`). Defer the polygon-footprint case to whenever footprint-aware costing
+  is turned on; the circular-clearance form is the shipping default. Logged as O-1 here.
+</content>

--- a/journal/2026-06/19-00-p3-margin-inflation-cost-critic-interface.md
+++ b/journal/2026-06/19-00-p3-margin-inflation-cost-critic-interface.md
@@ -1,0 +1,59 @@
+# P3 margin-inflation cost-critic interface — where epistemic k·σ enters nav2_mppi
+
+- **Cycle**: 2026-06-19 (KST)
+- **Branch**: `autoresearch/p3-margin-inflation-cost-critic-interface`
+- **TODO**: `37cc5d39` Spec margin-inflation cost-critic interface (sets up Q-008 k knob)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- Authored `docs/margin_inflation_cost_critic_interface.md`: the consumer end of the P3
+  risk-stack — fixes **where** the epistemic channel (idx 3) inflates the obstacle margin
+  inside the *actual* nav2_mppi critic stack (`CostCritic` + `inflation_layer` from
+  `config/nav2_mppi_params.yaml`).
+- Decided: a **standalone `RiskInflationCritic`**, not a `CostCritic` overload — and a
+  **tighten-only, bounded (≤ inflation_radius), mask-gated** `k·σ` rule (unobserved ⇒ no
+  inflation), epistemic-only (aleatoric → sibling CVaR term).
+- Restored the **Q-008** deliberation (it was missing from `deliberations.md` despite being
+  cited by `residual_in_rollout_reference.md` + STATE — lost in an earlier prepend conflict);
+  marked it `partially-answered` (routing resolved, `k` value still P5).
+
+## What worked / what failed
+- The interface dropped out cleanly because the three upstream docs (residual-in-rollout,
+  epistemic, stack-tensor) had each deferred the *exact same sentence* to "the critic doc" —
+  this cycle just had to honor those forward-references against the real config.
+- Avoided the D-011 trap: `decisions.md` top on main is still D-011 (D-012 lives only on
+  open #52), so prepending D-013 here would add/add-conflict with #52. Deferred the D-013
+  promotion; recorded the decision inline + in Q-008 instead. `deliberations.md` was safe
+  (its toucher #50 merged; #52 doesn't touch it).
+- Found a real data-loss bug: Q-008 had silently vanished from `deliberations.md` — the
+  concurrent-prepend conflict class D-011 targets has already cost one deliberation entry.
+
+## North-star delta
+- **P3 design lane is now complete**: rollout-wiring + epistemic render + aleatoric render +
+  stack-tensor contract + **margin-inflation routing** all specced. The variance→safety path
+  is fully drawn on paper; only code (blocked on #44/#45 reaching main) remains.
+- No measured numbers yet (still 0 — gated on the P5 harness + the user baseline run).
+
+## Key learnings
+- The obstacle margin can only be made representation-aware at the **critic** level, not the
+  costmap-inflation level: inflation is a global pre-rollout transform and can't vary per
+  cell by a field recomputed each control step. This pins all future risk-routing to critics.
+- `k=0` default is the discipline that lets P3 *plumbing* land and smoke-test before any
+  tuned gain exists — the ablation flips one number instead of wiring a critic under deadline.
+- Shared append-at-top docs keep losing entries to prepend conflicts; restoring Q-008 is a
+  reminder to grep for cited-but-missing Q/D ids when touching these files.
+
+## Recommended next 1–3 priorities
+1. (user) Merge the P2 build-path cluster (#44 keystone → #45 → #23) — every P3 code step
+   (ensemble → renderers → RiskInflationCritic) stays blocked until they reach main.
+2. After #52 merges: promote the `RiskInflationCritic` placement decision to `decisions.md`
+   as **D-013**, and batch the pending Q-010/Q-011 + O-1/O-2 promotions in one conflict-free
+   pass.
+3. Spec the **aleatoric → CVaR/chance-constraint** sibling cost term (idx 4 routing) — the
+   one remaining unspecced channel-routing half, now that epistemic routing is fixed.
+
+## Artifacts
+- PR: #53 (autoresearch/p3-margin-inflation-cost-critic-interface)
+- Files touched: docs/margin_inflation_cost_critic_interface.md, docs/deliberations.md, results/p3-margin-inflation-cost-critic-interface.tsv
+- TSV row appended: yes

--- a/results/p3-margin-inflation-cost-critic-interface.tsv
+++ b/results/p3-margin-inflation-cost-critic-interface.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-06-19T00:06:34+09:00	ed5a33f	qual:doc-only	in_progress	RiskInflationCritic placement (not CostCritic overload); k·σ tighten-only mask-gated margin; Q-008 routing resolved; restored lost Q-008


### PR DESCRIPTION
## Summary
- New `docs/margin_inflation_cost_critic_interface.md`: specs **where** the epistemic channel's `k·σ` enters the live nav2_mppi cost. Decision: a **standalone `RiskInflationCritic`** (not a `CostCritic` overload) — keeps a clean P5 ablation invariant (`k=0` ⇒ exact baseline) and an independent `cost_weight`.
- Margin rule: **tighten-only, bounded (≤ `inflation_radius`), mask-gated** (unobserved cells ⇒ no inflation, per the stack-tensor mask contract). Inflates effective obstacle footprint by `k·σ_pt` at each trajectory point; epistemic-only (aleatoric routes to the sibling CVaR term).
- `k` (Q-008) exposed as config, **default `0.0`** so the plumbing lands as a no-op before the P5 metric-driven sweep.
- Closes the **routing half of Q-008**; restored the Q-008 deliberation entry (it was lost from `deliberations.md` in an earlier concurrent-prepend conflict though still cited by `residual_in_rollout_reference.md` + STATE) and marked it `partially-answered`.
- D-013 (the critic-placement decision) deferred to a post-#52 cycle to avoid the D-011 `decisions.md` prepend-conflict trap — recorded inline in the doc + Q-008 for now.

## Test plan
- [x] Doc-only change → no `src/` touched, no build smoke needed
- [x] No root snapshot files staged (STATE/JOURNAL/RESULTS) — D-011 rule
- [x] Grounded in real config: `CostCritic` + `inflation_layer` from `config/nav2_mppi_params.yaml`

## Closes
- TODO `37cc5d39`: Spec margin-inflation cost-critic interface (https://www.notion.so/37cc5d39343d8171ba07caaa1ea76baf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)