### PR TITLE
[auto] P3 aleatoric risk cost-critic interface (chance-constraint/CVaR tightening, idx 4 routing)

### DIFF
--- a/docs/aleatoric_channel_bev_rendering.md
+++ b/docs/aleatoric_channel_bev_rendering.md
@@ -165,7 +165,10 @@ The implementing PR (post-#44, and only if #44 ships heteroscedastic heads) shou
   worthless channel that *looks* like a valid output. The §4-style acceptance check (spatial
   CoV floor) is the proposed guard, but the floor value is unset until #44 trains — same
   un-set-knob status as `k` (Q-008) and `σ²_ref` (Q-009).
-- **Aleatoric cost-routing entry point.** §4 fixes that routing is chance-constraint
-  tightening / CVaR, not margin inflation, but the concrete nav2_mppi insertion point is
-  unspecified — a sibling to the margin-inflation interface TODO, to be specced once that
-  one lands so they share the critic-config surface.
+- **Aleatoric cost-routing entry point — now specced.** §4 fixes that routing is
+  chance-constraint tightening / CVaR, not margin inflation; the concrete nav2_mppi
+  insertion point is now [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md)
+  (a standalone `AleatoricRiskCritic`, sibling of the epistemic margin critic, sharing
+  the critic-config surface), recorded as D-014. The remaining open knob is the risk
+  level `δ`/`α` (Q-012), a P5 metric-driven sweep. (Q-010/Q-011 above are now promoted
+  to deliberations.md.)

--- a/docs/aleatoric_risk_cost_critic_interface.md
+++ b/docs/aleatoric_risk_cost_critic_interface.md
@@ -1,0 +1,211 @@
+# Aleatoric Risk Cost-Critic Interface — where the chance-constraint / CVaR tightening enters nav2_mppi
+
+_Phase P3 · 2026-06-27 · specs the **exact point in the nav2_mppi cost** where the
+aleatoric channel (idx 4) applies a **risk-sensitive constraint tightening**, the
+sibling of the epistemic margin-inflation route. Interface/design only — no code
+dependency on the (merge-blocked) ensemble. This is the consumer end of the
+stack-tensor contract for the **aleatoric** row: the aleatoric channel
+([`aleatoric_channel_bev_rendering.md`](aleatoric_channel_bev_rendering.md), idx 4 of
+[`multi_channel_risk_bev_stack.md`](multi_channel_risk_bev_stack.md) §4) feeds the
+risk term specced here; its epistemic twin is
+[`margin_inflation_cost_critic_interface.md`](margin_inflation_cost_critic_interface.md)
+(idx 3). The rollout-wiring that produces the per-cell variance is
+[`residual_in_rollout_reference.md`](residual_in_rollout_reference.md).
+See [`decisions.md`](decisions.md) D-009/D-012/D-013, [`deliberations.md`](deliberations.md)
+Q-009/Q-010/Q-011._
+
+## 0. What this doc closes
+
+Three upstream docs all defer the same one sentence to "a sibling of the
+margin-inflation interface, to be specced once that one lands":
+
+- aleatoric_channel_bev_rendering.md §4 fixes that aleatoric routes as a
+  **chance-constraint / CVaR tightening, not margin inflation**, and §7 logs the
+  "concrete nav2_mppi insertion point" as an explicit follow-up — "to be specced once
+  [the margin interface] lands so they share the critic-config surface."
+- multi_channel_risk_bev_stack.md §4 routes row 4 (aleatoric) to "chance-constraint /
+  CVaR tightening" — pointing here.
+- margin_inflation_cost_critic_interface.md §5 states the epistemic critic consumes
+  **only** idx 3 and that "the aleatoric→risk-sensitive term is the sibling spec
+  (separate TODO); this doc owns the epistemic→margin route only."
+
+The margin-inflation interface (PR #53) has now merged, so the critic-config surface it
+established (a standalone risk critic, `k=0`-style no-op default, config-not-literal
+knobs, mask-gating) is available to mirror. The genuinely-new decision here: **which
+nav2_mppi cost term consumes the aleatoric channel, and how the predicted noise changes
+its output**, given the *actual* critic stack in `config/nav2_mppi_params.yaml`.
+
+## 1. Why this cannot reuse the margin-inflation route
+
+The epistemic route subtracts `k·σ` from clearance (a **geometry** change: obstacles
+treated as closer where the model is *ignorant*). Aleatoric noise is **irreducible** —
+it does not shrink with data — so feeding it into a back-off-where-ignorant margin would
+produce *permanent* over-conservatism that never improves as the model trains (the swap
+error tabulated in aleatoric §4). The correct response to irreducible noise is to
+**hedge a fixed risk**: respect a tighter collision-probability / penalize the
+distribution tail, reflecting that even a perfectly-trained model faces this noise.
+
+| | epistemic (idx 3, margin inflation) | aleatoric (idx 4, **this doc**) |
+|---|---|---|
+| signal | `Var_k μ_k` — ensemble disagreement (reducible) | `mean_k σ²_k` — mean predicted noise (irreducible) |
+| response | shrink clearance by `k·σ` (geometry) | tighten chance-constraint / CVaR tail penalty (risk) |
+| as data grows | margin → 0 (model learns) | term persists (noise is real) |
+| critic | `RiskInflationCritic` | `AleatoricRiskCritic` (this doc) |
+
+## 2. The actual obstacle terms — same two anchors as the epistemic doc
+
+Per margin_inflation_cost_critic_interface.md §1, only **`CostCritic`** (a) runs inside
+the per-rollout scoring loop and (b) consumes a spatial field at trajectory-point
+granularity; the `local_costmap` inflation layer is a global pre-rollout transform that
+cannot vary per cell by a field recomputed each control step. So — identically to the
+epistemic case — the aleatoric risk term must enter at the **critic** level.
+
+But the *form* differs. `CostCritic` scores a single nominal trajectory point against
+the costmap. A chance-constraint / CVaR term is **distributional**: it scores the
+trajectory point against a *risk measure of the collision event under the predicted
+noise*, not the nominal clearance alone. The aleatoric channel supplies exactly the
+per-cell noise scale that turns a deterministic clearance into a probabilistic one.
+
+> **Decision (→ D-014, pending decisions.md promotion): introduce a standalone
+> `AleatoricRiskCritic`, do not overload `CostCritic` or `RiskInflationCritic`.**
+> Same three reasons as D-013: (1) a separate critic keeps the baseline obstacle term
+> untouched, so disabling it reproduces the exact baseline trajectory (the P5 ablation
+> invariant); (2) it gives the aleatoric risk its own `cost_weight` independent of both
+> `CostCritic`'s 3.81 and the epistemic critic's gain; (3) it isolates the P5 tail-level
+> sweep (`α`/`δ` below) to one plugin. Critically, **epistemic and aleatoric stay two
+> critics, not one "uncertainty" critic** — collapsing them re-merges the epi/ale split
+> that is P3's reason for being, and the two consume different stack rows via different
+> math (clearance subtraction vs tail measure).
+
+## 3. The risk-tightening rule
+
+The aleatoric channel supplies, per ego-frame cell, a real-unit predictive standard
+deviation `σ_ale(x,y)` (the `sigma_raw` raster from aleatoric §3b — *not* the `[0,1]`
+form; risk math needs physical units). For a sampled trajectory point at ego-frame
+position `(x,y)` with nominal clearance `d(x,y)`:
+
+```
+σ_pt   = sample(sigma_raw_ale, x, y)         # NN-lookup into the aleatoric raster
+d_eff  = d(x,y) − z(δ) · σ_pt                # chance-constraint form: shrink clearance by
+                                             # a fixed quantile of the noise, NOT by k·σ
+cost_pt = barrier(d_eff)                      # same barrier shape CostCritic uses
+```
+
+The chance-constraint form looks superficially like the epistemic `d − k·σ`, but the
+multiplier is **fixed by a target collision probability `δ`** (`z(δ)` = the `(1−δ)`
+Gaussian quantile, e.g. `z=1.64` for `δ=0.05`), *not* a tunable margin gain. The
+semantic difference is load-bearing: `k` (epistemic) is "how much to distrust the model
+here" and goes to 0 as the model learns; `z(δ)` (aleatoric) is "the safety probability I
+demand against irreducible noise" and is a **fixed risk appetite** the operator sets
+once. They are not the same knob with a different name.
+
+### CVaR variant (preferred when the noise is non-Gaussian)
+
+When the predictive distribution is heavy-tailed (the variance head's Gaussian
+assumption is only a first cut), a **CVaR (expected-shortfall) tail penalty** is the
+more honest risk measure than a single quantile:
+
+```
+cost_pt += w_ale · CVaR_α[ collision_cost | noise ]    # mean cost over the worst-α tail
+```
+
+with `CVaR_α` the average barrier cost over the worst `α`-fraction of the noise
+distribution at that point (for a Gaussian `σ_pt`, `CVaR_α` has a closed form
+∝ `σ_pt · φ(z_α)/α`, so no sampling is needed at control rate). Ship the
+**chance-constraint quantile form as the default** (cheaper, one lookup) and expose CVaR
+as a config-selectable risk measure for the heavy-tail case.
+
+Key properties this rule must preserve (mirroring the epistemic doc's invariants):
+
+- **Tightening only ever tightens, never loosens.** `z(δ) ≥ 0`, `σ ≥ 0` ⇒ `d_eff ≤ d`.
+  A representation channel must never *reduce* a margin and drive into an obstacle.
+- **Bounded.** Clamp `z(δ)·σ_pt ≤ Δ_max_ale` (config) so a pathological σ spike cannot
+  freeze the robot. Defaults to the costmap `inflation_radius` (0.4 m), same ceiling as
+  the epistemic clamp — never tighten beyond the existing safety layer.
+- **Persists with data.** Unlike the epistemic margin, this term must **not** be expected
+  to vanish as the model trains — that is the whole point. The P5 win condition is *fewer
+  near-misses in genuinely-noisy regions at fixed success/time-to-goal*, not "the term
+  goes to zero."
+
+## 4. Unobserved cells — no tightening (mask-gated)
+
+Per the stack-tensor contract (multi_channel_risk_bev_stack.md §2) the aleatoric row
+travels with an observability plane (mask idx 4). The critic **must** gate on it,
+exactly as the epistemic critic does:
+
+```
+σ_pt_effective = mask[ALEATORIC, x, y] ? σ_pt : 0.0
+```
+
+- mask `0` (no rollout sample landed in that cell) ⇒ **no tightening**. The planner
+  isn't considering trajectories there, so there is nothing to make risk-sensitive; the
+  *occupancy* safety of unseen cells is the costmap's job, not this critic's.
+- The critic must never read an unobserved cell as `σ=high` (phantom risk on every
+  missed cell) nor as a confident `σ=0`. The mask is the only correct disambiguator —
+  the same reason the stack doc carries it explicitly rather than as a NaN sentinel.
+
+## 5. The knobs (`δ` / `α` / risk-measure) — config, never literals
+
+This doc routes the tail level but **does not set** it — like Q-008's `k`, the risk
+appetite is a P5 metric-driven choice. The interface obligation is only that every knob
+is a documented plugin parameter, defaulted, never hard-coded:
+
+```yaml
+AleatoricRiskCritic:
+  enabled: true
+  cost_power: 1
+  cost_weight: 0.0           # DEFAULT 0.0 ⇒ exact-baseline no-op until tuned (D-013 discipline)
+  risk_measure: chance       # "chance" (quantile) | "cvar"; chance is the cheap default (§3)
+  chance_delta: 0.05         # target per-point collision prob; z(0.05)=1.64. P5-tuned.
+  cvar_alpha: 0.10           # worst-α tail fraction when risk_measure=cvar. P5-tuned.
+  max_tighten_m: 0.4         # == local_costmap inflation_radius; hard upper clamp
+  aleatoric_channel_index: 4 # RiskChannel.ALEATORIC (stack-tensor enum, never guessed)
+  trajectory_point_step: 2   # match CostCritic so the two score the same points
+```
+
+**`cost_weight` defaults to `0.0`** (not `chance_delta` — `δ` has no meaningful "off"
+value, but a zero weight is a clean no-op). This mirrors the epistemic critic's `k=0`
+default: shipping the critic disabled makes it identical to baseline, so the *plumbing*
+can land and be smoke-tested before any tuned risk level exists, and the P5 ablation
+flips a single number rather than wiring a new critic under deadline.
+
+## 6. Acceptance / what "done" looks like (when code unblocks)
+
+The implementing PR (post-#44, post-ensemble, post-aleatoric-render, and only if #44
+ships **heteroscedastic** heads — Q-010) should satisfy:
+
+1. An `AleatoricRiskCritic` nav2_mppi critic plugin registered alongside the existing 8
+   (`ConstraintCritic`, `CostCritic`, `GoalCritic`, `GoalAngleCritic`, `PathAlignCritic`,
+   `PathFollowCritic`, `PathAngleCritic`, `PreferForwardCritic`) and the epistemic
+   `RiskInflationCritic` — **off by default via `cost_weight=0`** so adding it to the
+   `critics:` list is a no-op until tuned.
+2. It samples `sigma_raw_ale` + `mask` (aleatoric channel, idx 4) at each trajectory
+   point, applies §3's bounded, tighten-only, mask-gated chance-constraint (or CVaR)
+   tightening, and adds the resulting cost.
+3. `risk_measure`, `chance_delta`, `cvar_alpha`, `max_tighten_m`, `aleatoric_channel_index`,
+   `trajectory_point_step` are all config (§5) — no literals.
+4. Disabling the critic (or `cost_weight=0`) reproduces the exact baseline trajectory —
+   the ablation invariant.
+5. With **both** risk critics enabled, an epistemic-only ablation (`AleatoricRiskCritic`
+   off) and an aleatoric-only ablation (`RiskInflationCritic` off) are each one config
+   flag — the two-axis P5 study the epi/ale split exists to enable.
+6. `qual:` metric pre-P5; the quantitative gate is the P5 near-miss-rate sweep over
+   `δ`/`α` once the eval harness lands — fewer near-misses in noisy regions at fixed
+   success/time-to-goal is the win condition (and unlike the epistemic term, this one is
+   *not* expected to trend toward zero as the model improves).
+
+## 7. Open questions raised (→ deliberations)
+
+- **Q-012 (the risk level `δ`/`α`) — new, P5-deferred.** This doc resolves *where* and
+  *how* the aleatoric tail enters (→ the `AleatoricRiskCritic`, chance-constraint default
+  with CVaR option) but not *what δ/α are*; that is a P5 metric-driven sweep, the
+  aleatoric sibling of Q-008's `k`. Logged to deliberations.md.
+- **Gaussian-tail vs empirical-CVaR.** §3 gives the Gaussian closed-form CVaR; if the
+  variance head is later replaced by a quantile/distributional head, the closed form no
+  longer holds and CVaR must be estimated from samples (cost at control rate). Defer the
+  distributional-head case to whenever such a head exists; the Gaussian form is the
+  shipping default. Logged as O-2 (sibling of the epistemic doc's O-1 footprint case).
+- **Hard dependency on heteroscedastic heads (Q-010) carries through.** If #44 ships MSE
+  point heads, there is no aleatoric signal, so this critic has nothing to consume — it
+  is built only after the aleatoric channel renders a non-degenerate field (Q-011's
+  heteroscedasticity acceptance check passes).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,6 +13,22 @@
 
 ---
 
+## D-014 — 2026-06-27 — Aleatoric risk routes via a standalone `AleatoricRiskCritic` (chance-constraint / CVaR tightening), separate from the epistemic margin critic
+
+- **Context**: aleatoric 채널 스펙(#51 §4) 과 stack 문서(#52 §4) 가 모두 "aleatoric(idx 4) 의 nav2_mppi 진입점은 margin-inflation interface 의 sibling 으로, 그것이 land 한 뒤 critic-config surface 를 공유하며 별도 스펙한다"고 follow-up 으로 미뤘다. epistemic margin interface(#53, D-013) 가 머지되어 이제 그 surface 를 mirror 할 수 있다. 남은 질문: aleatoric 비가역(irreducible) 노이즈를 *어느* cost term 이 소비하고 *어떻게* 출력을 바꾸나.
+- **Decision**: 독립 `AleatoricRiskCritic` 도입 — `CostCritic` 도 `RiskInflationCritic` 도 overload 하지 않음. epistemic 은 clearance 에서 `k·σ` 를 빼는 **geometry** 변경(무지 → 후퇴, 데이터 늘면 0 으로 소멸)이지만, aleatoric 은 비가역이므로 같은 margin 에 먹이면 영구 과보수가 된다. 따라서 aleatoric 은 **risk-sensitive constraint tightening**: chance-constraint 형 `d_eff = d − z(δ)·σ`(기본, `z(δ)`=고정 quantile) + 옵션 CVaR tail penalty. tighten-only / `Δ_max` clamp / mask-gated, `cost_weight=0.0` 기본(no-op, baseline 재현 → P5 ablation 한 숫자). epistemic·aleatoric 를 두 critic 으로 유지해야 P3 epi/ale split + 2-axis ablation 이 성립.
+- **Alternatives**: (a) `CostCritic` overload — baseline 측정 불가, ablation 파괴. (b) epistemic critic 에 aleatoric 합치기 — epi/ale split 재붕괴, 서로 다른 row·수식(clearance 차감 vs tail measure). (c) margin-inflation `k·σ` 재사용 — 비가역 노이즈에 영구 과보수, 데이터로 안 줄어듦(swap error). 모두 기각.
+- **Status**: accepted
+- **Refs**: 이 cycle PR(aleatoric-cvar) + `docs/aleatoric_risk_cost_critic_interface.md` + journal/2026-06/27-00-p3-aleatoric-cvar-chance-constraint-critic.md; sibling D-013; Q-012 신규
+
+## D-013 — 2026-06-19 — Epistemic margin routes via a standalone `RiskInflationCritic`, not a `CostCritic` overload
+
+- **Context**: residual_in_rollout_reference §Axis-2 가 variance→safety 경로로 margin inflation(option 2, `cost+=λσ²` 아님)을 골랐고, epistemic 채널(#50)·stack(#52)·margin interface(#53) 가 모두 "epistemic `k·σ` 가 nav2_mppi cost 의 *어디로* 들어가나"를 한 문장씩 미뤘다. 실제 config 의 obstacle term 은 `CostCritic`(per-rollout, spatial field 소비)와 costmap `inflation_layer`(global pre-rollout) 둘뿐 — 후자는 control-step 마다 갱신되는 epistemic field 로 셀별 margin 을 못 바꾼다. (이 결정은 #53 에서 내려졌으나 당시 #52 가 decisions.md D-012 prepend 를 점유 중이라 D-011 conflict trap 회피 위해 margin 문서 §1 + Q-008 에만 기록, decisions.md 승격은 후속 cycle 로 deferred 됨.)
+- **Decision**: 독립 `RiskInflationCritic` 도입(`CostCritic` overload 금지). baseline obstacle term 무손상(critic 끄면 정확히 baseline → P5 ablation invariant), epistemic margin 에 `CostCritic` 3.81 과 독립인 `cost_weight`, P5 `k`-sweep 를 한 plugin 에 격리. `k_margin_per_sigma=0.0` 기본(no-op), tighten-only / `Δ_max≤inflation_radius` clamp / mask-gated, epistemic-only(idx 3).
+- **Alternatives**: (a) `CostCritic` overload — 두 gain 이 한 weight 에 엉켜 "representation 없는 MPPI" 측정 불가, P5 ablation 치명. (b) costmap-layer 진입 — global·static, 셀별·step별 변동 불가. 모두 기각.
+- **Status**: accepted
+- **Refs**: PR #53 (merged) + `docs/margin_inflation_cost_critic_interface.md` §1; sibling D-014; Q-008(routing half resolved, `k` value still P5)
+
 ## D-012 — 2026-06-17 — Canonical multi-channel risk BEV stack: fixed 5-channel order + explicit unobserved-mask (NaN-distinct-from-zero)
 
 - **Context**: epistemic (#50) 와 aleatoric (#51) 채널 스펙이 각각 "나는 `[5,H,W]` 스택의 row _k_ 이고, 채널 순서 + mask 계약은 stack 문서가 소유한다"고 forward-reference 만 남긴 상태였다. 소유 문서가 없으면 채널이 하나씩 land 할 때마다 MPPI cost critic 입력 shape 가 재협상되어 churn 한다. 또한 risk `0.0` 의 의미가 모호 — "평가됨·확신의 0" vs "미평가/미관측" 이 구분 안 되면 planner 가 미관측(가려진) 셀을 zero-risk 로 읽고 진입하는 north-star 실패모드가 생긴다.

--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -11,6 +11,33 @@
 
 ---
 
+## Q-012 — 2026-06-27 — `[uncertainty]` aleatoric risk level `δ` / `α`: 어떻게 set 하나 (chance-constraint / CVaR tightening)
+
+- **Question**: `AleatoricRiskCritic` 가 aleatoric `σ` 로 clearance 를 `z(δ)·σ` 만큼 조이거나 CVaR_α tail 을 벌점할 때, target collision prob `δ` (quantile) / tail fraction `α` 를 어디서 얻나. Q-008 의 `k` (epistemic margin gain) 의 aleatoric 형제 knob.
+- **Trade-off**:
+  - **measured near-miss rate 로 sweep**: 의미 있는 risk 수준, 그러나 P5 eval harness (near-miss/success/time-to-goal) 전엔 없음
+  - **hand-pick (예: δ=0.05)**: 즉시 진행, 그러나 임의 — 노이즈 분포·환경에 안 맞을 수 있음
+- **Lean**: documented placeholder (`chance_delta=0.05`, `cvar_alpha=0.10`), `cost_weight=0.0` no-op 기본 → P5 measured near-miss 로 calibrate. `k`(Q-008)·`σ²_ref`(Q-009)·`σ²_ref_ale`(Q-011) 와 함께 한 sweep 에 묶음. epistemic `k` 와 달리 데이터 늘어도 0 으로 안 감 (비가역).
+- **다음 action**: P5 risk-calibration harness 확보 시 `δ`/`α` set → resolve 시 D-MMM. ref: [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md) §3/§5.
+
+## Q-011 — 2026-06-15 — `[uncertainty]` aleatoric homoscedastic degeneracy guard: spatial-CoV floor 값은
+
+- **Question**: variance head 가 global 단일 노이즈(homoscedastic) 로 collapse 하면 aleatoric 채널이 spatial 정보 0 인 flat raster 가 되는데(유효해 *보이는* 무효 출력), 이를 acceptance 에서 거르는 spatial coefficient-of-variation floor 값을 얼마로.
+- **Trade-off**:
+  - **엄격한 floor**: collapse 확실히 거름, 그러나 진짜로 균일하게 노이지한 환경을 false-fail
+  - **느슨한 floor**: false-fail 적음, 그러나 부분 collapse 통과
+- **Lean**: floor 는 #44 가 학습된 뒤에야 set 가능 (`k`/`σ²_ref` 와 같은 un-set 상태). varied-terrain/varied-`(v,ω)` slice 의 측정 CoV 분포로 정함. 채널이 flat ⇒ upstream head-training 버그(렌더러 아님).
+- **다음 action**: #44 (heteroscedastic head) land + 학습 후 측정 → floor set. ref: [`aleatoric_channel_bev_rendering.md`](aleatoric_channel_bev_rendering.md) §2/§4.
+
+## Q-010 — 2026-06-15 — `[arch]` D-009 ensemble head: heteroscedastic (NLL) vs MSE point — aleatoric 채널 존재 여부를 가름
+
+- **Question**: D-009 scaffold (PR #44) 의 ensemble head 가 per-dim 예측분산 `σ²_k` 를 내는 heteroscedastic(NLL 학습) 인가, 단순 MSE point regression 인가. 후자면 aleatoric 신호가 *아예 없어* aleatoric 채널·`AleatoricRiskCritic` 둘 다 build 불가. epistemic 은 means 만 필요해 영향 없음.
+- **Trade-off**:
+  - **NLL variance heads**: epi/ale split (핵심 P3 deliverable) unlock, 비용은 출력 dim +1 + Gaussian NLL loss
+  - **MSE point heads**: 단순, epistemic-only, 그러나 P3 의 절반(aleatoric)을 포기
+- **Lean**: NLL heads — epi/ale split 이 P3 의 reason-for-being 이고 추가 비용이 새 모델이 아니라 출력 1차원 + loss 교체뿐.
+- **다음 action**: #44 머지 전 scaffold 가 head type 확정해야 함 (user/구현 cycle). resolve 시 D-MMM. ref: [`aleatoric_channel_bev_rendering.md`](aleatoric_channel_bev_rendering.md) §1/§7.
+
 ## Q-009 — 2026-06-13 — `[uncertainty]` epistemic channel 정규화 기준 `σ²_ref`: 어떻게 set 하나
 
 - **Question**: ensemble `σ²` 를 BEV 채널 `[0,1]` 로 매핑할 때 fixed reference `σ²_ref` 가 필요한데 (per-frame min-max 는 cross-frame 비교성 파괴 → P5 calibration metric 무력화), 그 값을 어디서 얻나. Q-008 의 `k` margin gain 과 형제 knob.

--- a/docs/multi_channel_risk_bev_stack.md
+++ b/docs/multi_channel_risk_bev_stack.md
@@ -116,8 +116,8 @@ doc §4):
 |---|---|---|
 | static, dynamic | occupancy / collision likelihood | additive obstacle cost (+ dynamic chance-constraint, P4) |
 | traversability | preference / soft cost | additive weighted cost |
-| epistemic | **margin inflation** `k·σ` — back off where the model is ignorant (reducible) | obstacle-margin gain → TODO `37cc5d39-…-8171` |
-| aleatoric | **chance-constraint / CVaR tightening** — hedge irreducible noise (does not vanish with data) | risk-sensitive term, sibling spec |
+| epistemic | **margin inflation** `k·σ` — back off where the model is ignorant (reducible) | `RiskInflationCritic` → [`margin_inflation_cost_critic_interface.md`](margin_inflation_cost_critic_interface.md) (D-013) |
+| aleatoric | **chance-constraint / CVaR tightening** — hedge irreducible noise (does not vanish with data) | `AleatoricRiskCritic` → [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md) (D-014) |
 
 The two model-uncertainty rows route through **different mechanisms** (margin vs
 chance-tightening); the stack tensor must therefore stay channel-addressable to the very

--- a/journal/2026-06/27-00-p3-aleatoric-cvar-chance-constraint-critic.md
+++ b/journal/2026-06/27-00-p3-aleatoric-cvar-chance-constraint-critic.md
@@ -1,0 +1,54 @@
+# P3 aleatoric risk cost-critic interface (chance-constraint / CVaR)
+
+- **Cycle**: 2026-06-27 00:00 KST
+- **Branch**: `autoresearch/p3-aleatoric-cvar-chance-constraint-critic`
+- **TODO**: `p3-aleatoric-cvar` Spec the aleatoric → CVaR / chance-constraint sibling cost-critic interface (stack idx 4)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- Authored `docs/aleatoric_risk_cost_critic_interface.md` — the consumer end of the
+  aleatoric (idx 4) stack row, sibling of the merged epistemic margin interface (#53).
+  Routes irreducible noise via a **standalone `AleatoricRiskCritic`**: chance-constraint
+  `d_eff = d − z(δ)·σ` tightening (default) + optional Gaussian closed-form **CVaR** tail
+  penalty; tighten-only / `Δ_max`-clamped / mask-gated; `cost_weight=0` no-op default.
+- Promoted the deferred **D-013** (epistemic critic placement, from #53) + new **D-014**
+  (this) into decisions.md — now conflict-free post-#52/#53 merge.
+- Promoted **Q-010/Q-011/Q-012** into deliberations.md and cross-linked stack §4 + aleatoric §7.
+
+## What worked / what failed
+- Timing was exactly right: aleatoric render doc §4/§7 explicitly deferred this to "a
+  sibling of the margin interface, once it lands so they share the config surface" — #53
+  merged at 23:00 KST this very cycle, so the sibling could finally be written.
+- Caught dangling refs: Q-010/Q-011 were cited by the merged #51 doc but never existed in
+  deliberations.md (the recurring prepend-data-loss pathology) — promoted them, closing the gap.
+- Pure design/doc; no code, so no build risk. The epi/ale split is now load-bearing in the
+  critic stack (two critics, two stack rows, two mechanisms — never collapsed).
+
+## North-star delta
+- **P3 variance→safety routing design lane is now COMPLETE**: both model-uncertainty rows
+  have concrete nav2_mppi critic specs (epistemic→margin `RiskInflationCritic`,
+  aleatoric→risk `AleatoricRiskCritic`) sharing one config surface, both with `=0` ablation no-ops.
+- No measured numbers yet (still 0). All remaining P3 forward motion is now gated purely on
+  P2 build-path code reaching main — the doc lane has genuinely run out of conflict-free work.
+
+## Key learnings
+- The epistemic `k` and aleatoric `z(δ)`/`α` look like the same "multiply σ" knob but are
+  semantically distinct: `k`→0 as the model learns (reducible distrust), `δ`/`α` are a fixed
+  risk appetite that persists (irreducible noise). Conflating them is the P3-defining error.
+- When an append-at-top shared doc (decisions/deliberations) is free of open-PR contention,
+  batch ALL pending promotions in one pass — it's the cheapest moment and prevents the
+  dangling-ref data loss that bit Q-008/Q-010/Q-011.
+
+## Recommended next 1–3 priorities
+1. (user) **Merge the P2 build-path cluster #44→#45→#23** — the sole gate on every P3 code
+   step (ensemble → renderers → stack → both risk critics). The entire P3 design is now spec-complete.
+2. (claude, if any conflict-free doc work remains) audit P3 spec docs for any other
+   forward-reference / dangling Q-D id before the lane fully idles on P2.
+3. (P5) the `δ`/`α` (Q-012) + `k` (Q-008) + `σ²_ref`/`σ²_ref_ale` (Q-009/Q-011) sweep all
+   land in one risk-calibration harness — note for the P5 eval-harness design.
+
+## Artifacts
+- PR: #54 (https://github.com/Geonhee-LEE/Representation-Aware-MPPI/pull/54)
+- Files touched: docs/aleatoric_risk_cost_critic_interface.md (new), docs/decisions.md, docs/deliberations.md, docs/aleatoric_channel_bev_rendering.md, docs/multi_channel_risk_bev_stack.md, results/p3-aleatoric-cvar-chance-constraint-critic.tsv
+- TSV row appended: yes

--- a/results/p3-aleatoric-cvar-chance-constraint-critic.tsv
+++ b/results/p3-aleatoric-cvar-chance-constraint-critic.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-06-27T00:07:11+09:00	698dde9	qual:doc-only	keep	AleatoricRiskCritic interface: chance-constraint/CVaR tightening (idx4), D-013/D-014, Q-010/011/012; P3 routing lane complete


### PR DESCRIPTION
## Summary
- New `docs/aleatoric_risk_cost_critic_interface.md` — specs the **`AleatoricRiskCritic`**, the consumer end of the aleatoric (idx 4) stack row and sibling of the epistemic `RiskInflationCritic` (#53). Routes **irreducible** noise via a **chance-constraint** `d_eff = d − z(δ)·σ` tightening (+ optional **CVaR** tail penalty), explicitly **not** margin inflation (that would be permanent over-conservatism). Standalone critic, `cost_weight=0` no-op default (baseline-reproducing ablation invariant), tighten-only / `Δ_max`-clamped / mask-gated.
- Promotes **D-013** (epistemic critic placement, deferred from #53 to dodge the D-011 conflict trap) **+ D-014** (this aleatoric decision) into `decisions.md` — now conflict-free post-#52/#53 merge.
- Promotes **Q-010 / Q-011 / Q-012** into `deliberations.md` (Q-010/Q-011 were cited by the merged aleatoric render doc but missing from the log — dangling refs; Q-012 = the new `δ`/`α` risk-level knob, aleatoric sibling of Q-008's `k`).
- Cross-links the now-existing sibling into `multi_channel_risk_bev_stack.md` §4 + `aleatoric_channel_bev_rendering.md` §7.
- **Completes the P3 variance→safety routing design lane**: both model-uncertainty rows (epistemic→margin, aleatoric→risk) now have concrete critic specs sharing one config surface. All forward motion now gated purely on P2 build-path code reaching main.

## Test plan
- [x] Doc-only change → all referenced sibling docs exist (link check passed); no `src/` touched (no build smoke needed)
- [x] No snapshot files (STATE/JOURNAL/RESULTS) on branch (D-011 guard passed)
- [x] decisions.md / deliberations.md edited conflict-free (no open PR touches the doc logs)

## Closes
- TODO `p3-aleatoric-cvar`: Spec the aleatoric → CVaR / chance-constraint sibling cost-critic interface (stack idx 4 routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)