### PR TITLE
[auto] Promote deferred D-015 + Q-013 to canonical decision/deliberation logs

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,6 +13,14 @@
 
 ---
 
+## D-015 — 2026-06-29 — 다섯 P3 uncertainty knob 의 calibration 을 단일 harness `eval/calibrate_risk.py` 가 소유 (coupled `(k,δ)` joint sweep)
+
+- **Context**: P3 variance→safety 설계 lane (D-009/D-013/D-014) 가 5개 tuning knob (`k`/`δ`/`α`/`σ²_ref`/`σ²_ref_ale`) 을 남겼으나 각각 다른 deliberation (Q-008/009/011/012) 에 parked, calibration *절차*의 owner 가 없었다. 5개 독립 grid search 는 (a) launch/aggregation plumbing 5중복, (b) `k·σ`(epistemic)·`z(δ)·σ_ale`(aleatoric) 가 *같은* effective clearance `d_eff` 를 조이는 cross-knob coupling 을 놓침 → 격리 튜닝 시 안전 이중계상·corridor 과수축. (이 결정은 #55 가 land 했으나 당시 #55 자신이 decisions.md prepend 를 점유 → D-011 conflict trap 회피 위해 `p5_risk_calibration_harness.md` §1 에만 `(→D-015)` 로 기록, 승격은 이 cycle 로 deferred.)
+- **Decision**: 단일 calibration harness `eval/calibrate_risk.py` 가 5 knob 의 joint sweep 을 소유. 새 metric·새 launch path 도입 X — 기존 `run_metrics`/`path_tracking_metrics` JSON 재사용하는 thin driver (knob-vector → 두 critic config → 시나리오별 launch → `runs/<id>.json` readback → sweep TSV 1행/(knob-vector×scenario)). refs 는 documented default 로 freeze, `(k,δ)` 2-D plane (primary 4×4) + `cvar_alpha` 1-D secondary 만 sweep (~16+3 점×N, not `O(n^5)`). `k=0,cost_weight=0` baseline row 가 no-critic 숫자를 byte-for-byte 재현 → harness 가 behavior 아닌 search 만 추가함을 증명. (near-miss, time-to-goal) Pareto front 를 시나리오별 emit (premature scalarization X — trade rate 는 user 가 front 본 뒤 선택).
+- **Alternatives**: (a) knob 당 독립 grid 5개 — plumbing 중복 + coupling 무시로 과보수 operating point. (b) 단일 scalar objective 로 즉시 collapse — trade rate 가 front 관측 전에 baked-in. (c) full 5-D grid — combinatorial. 모두 기각.
+- **Status**: accepted
+- **Refs**: PR #55 (merged) + `docs/p5_risk_calibration_harness.md` §1/§2 + journal/2026-06/29-23-p5-promote-d015-q013-deferred-refs.md; Q-013 신규 (sweep strategy); knobs Q-008/Q-009/Q-011/Q-012
+
 ## D-014 — 2026-06-27 — Aleatoric risk routes via a standalone `AleatoricRiskCritic` (chance-constraint / CVaR tightening), separate from the epistemic margin critic
 
 - **Context**: aleatoric 채널 스펙(#51 §4) 과 stack 문서(#52 §4) 가 모두 "aleatoric(idx 4) 의 nav2_mppi 진입점은 margin-inflation interface 의 sibling 으로, 그것이 land 한 뒤 critic-config surface 를 공유하며 별도 스펙한다"고 follow-up 으로 미뤘다. epistemic margin interface(#53, D-013) 가 머지되어 이제 그 surface 를 mirror 할 수 있다. 남은 질문: aleatoric 비가역(irreducible) 노이즈를 *어느* cost term 이 소비하고 *어떻게* 출력을 바꾸나.

--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -11,6 +11,16 @@
 
 ---
 
+## Q-013 — 2026-06-29 — `[uncertainty]` coupled knob-vector 의 sweep 전략: 2-D `(k,δ)` plane vs full grid vs coordinate-descent
+
+- **Question**: D-015 의 calibration harness 가 5 knob (`k`/`δ`/`α`/`σ²_ref`/`σ²_ref_ale`) 을 어떤 전략으로 sweep 하나. full 5-D grid (기각, combinatorial) vs **2-D `(k,δ)` plane + refs frozen** (harness 문서 default) vs coordinate-descent (저렴하나 `k`↔`σ²_ref` 결합 valley 에서 stall).
+- **Trade-off**:
+  - **full grid**: unbiased 이나 `O(n^5)` — 사실상 실행 불가
+  - **2-D `(k,δ)` plane + refs frozen**: refs 가 gain 과 separable 가정 (1차 근사 true, §1) — 가장 적은 점수로 coupling 의 핵심(`k`·`δ` 가 같은 `d_eff` 조임)을 본다
+  - **coordinate-descent**: 최저가이나 `k`↔`σ²_ref` redundancy 를 가장 못 다룸 — 결합 valley 에서 stall
+- **Lean**: 2-D `(k,δ)` plane + refs 를 documented default 로 freeze; ±2× ref perturbation 에 Pareto front 가 움직이면 그때만 1-D ref sensitivity pass 추가.
+- **다음 action**: P5 cycle 이 첫 measured `(k,δ)` Pareto front 에 대해 resolve → D-MMM 승격. ref: [`p5_risk_calibration_harness.md`](p5_risk_calibration_harness.md) §2/§5.
+
 ## Q-012 — 2026-06-27 — `[uncertainty]` aleatoric risk level `δ` / `α`: 어떻게 set 하나 (chance-constraint / CVaR tightening)
 
 - **Question**: `AleatoricRiskCritic` 가 aleatoric `σ` 로 clearance 를 `z(δ)·σ` 만큼 조이거나 CVaR_α tail 을 벌점할 때, target collision prob `δ` (quantile) / tail fraction `α` 를 어디서 얻나. Q-008 의 `k` (epistemic margin gain) 의 aleatoric 형제 knob.

--- a/docs/p5_risk_calibration_harness.md
+++ b/docs/p5_risk_calibration_harness.md
@@ -8,9 +8,9 @@ the existing quantitative output [`run_metrics.md`](run_metrics.md) /
 [`path_tracking_metrics.md`](path_tracking_metrics.md) and the two risk critics
 ([`margin_inflation_cost_critic_interface.md`](margin_inflation_cost_critic_interface.md),
 [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md)).
-The harness-ownership decision below is recorded here pending promotion to **D-015** once
-[`decisions.md`](decisions.md) is conflict-free (open PR #54 currently holds the
-D-013/D-014 prepend — D-011 conflict trap)._
+The harness-ownership decision below was **promoted to D-015** (2026-06-29, once #55 merged
+and [`decisions.md`](decisions.md) became conflict-free); the open question is **promoted to
+Q-013** in [`deliberations.md`](deliberations.md)._
 
 ## 0. What this doc closes
 
@@ -134,7 +134,7 @@ env-specific divergence visible (a `k` good for `cafe` may over-detour in `small
   until (a) the P2 ensemble lands on main so the channels render, and (b) the two critics
   are implemented. It is the spec a P5 cycle picks up cold once those unblock.
 
-## 5. Open question (→ Q-013, recorded here pending deliberations.md being conflict-free)
+## 5. Open question (promoted to Q-013 in `deliberations.md`, 2026-06-29)
 
 > `[uncertainty]` **Sweep strategy for the coupled knob vector**: full 5-D grid (rejected —
 > combinatorial) vs the **2-D `(k, δ)` plane with frozen refs** (this doc's default) vs
@@ -164,5 +164,5 @@ _Cross-refs: [`run_metrics.md`](run_metrics.md) · [`path_tracking_metrics.md`](
 [`margin_inflation_cost_critic_interface.md`](margin_inflation_cost_critic_interface.md) ·
 [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md) ·
 [`multi_channel_risk_bev_stack.md`](multi_channel_risk_bev_stack.md) ·
-[`decisions.md`](decisions.md) D-009/D-013/D-014 (→D-015) ·
-[`deliberations.md`](deliberations.md) Q-008/Q-009/Q-011/Q-012 (→Q-013)._
+[`decisions.md`](decisions.md) D-009/D-013/D-014/**D-015** ·
+[`deliberations.md`](deliberations.md) Q-008/Q-009/Q-011/Q-012/**Q-013**._

--- a/journal/2026-06/29-23-p5-promote-d015-q013-deferred-refs.md
+++ b/journal/2026-06/29-23-p5-promote-d015-q013-deferred-refs.md
@@ -1,0 +1,34 @@
+# Promote deferred D-015 + Q-013 into the canonical logs
+
+- **Cycle**: 2026-06-29 23:00 KST
+- **Branch**: `autoresearch/p5-promote-d015-q013-deferred-refs`
+- **TODO**: `p5-promote-d015-q013` (authored — STATE `Next claude-actionable` #1 dangling-ref audit; Notion MCP unavailable this cron run)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- The Curator merged #54/#55 at exactly this cycle's boundary (14:00:49–55Z), draining the queue 6→4 — the drain STATE predicted for *06-30* actually landed *now*, so the executor became feasible a cycle early.
+- Ran the STATE-flagged P3/P5 dangling-ref audit. Finding: D-015 (calib-harness ownership) and Q-013 (sweep strategy) were recorded *inline* in `p5_risk_calibration_harness.md` (06-27, #55) with their `decisions.md`/`deliberations.md` prepends **deferred** to dodge the D-011 conflict trap.
+- With #55 now merged and all 4 remaining open PRs P2 build-path (verified zero contention on the two logs), promoted both entries and marked the harness doc's two pending-promotion notes resolved.
+
+## What worked / what failed
+- Clean conflict-free promotion: only `decisions.md` + `deliberations.md` + the harness doc + a new TSV touched; no snapshot files, no `src/`, no contention with the 4 open PRs.
+- Verified post-edit: D-015/Q-013 each present exactly once; the only residual `(→D-015)` is inside D-015's own historical-context sentence (intentional).
+- Notion MCP was unauthenticated in this cron run (headless limitation) — TODO reconciliation/announce-id fell back to a synthetic id; flagged for PLAN_NEXT.
+
+## North-star delta
+- No motion on measured numbers (still 0 — gated on P2). Pure design-lane hygiene.
+- But the audit trail is now coherent: the two highest design decisions of the P3→P5 bridge live in the canonical ADR/deliberation logs instead of buried in a spec doc — D-008's whole point, and what a future P5 cycle reads cold.
+
+## Key learnings
+- The "low-value, defer-while-queue≥6" audit STATE parked was actually *higher* value once #55 merged: it wasn't a generic dangling-ref sweep, it was recovering two real deferred decisions before they rotted. The conflict-free doc lane re-opens the moment the contending PR merges — worth re-checking each cycle, not assuming "exhausted" is permanent.
+- The Curator/executor 23:00 co-fire creates a race: the queue snapshot can read stale (pre-merge). Always recompute queue depth *after* `git fetch` near the top of the hour before trusting a `pr-queue-full` skip.
+
+## Recommended next 1–3 priorities
+- (user) Merge the P2 build-path cluster #44 (keystone) → #45 → #23, then #24. Still the sole gate on ALL P3 code (ensemble → renderers → critics → this calibration harness).
+- (claude) Doc lane is now genuinely thin again — next conflict-free candidate is small. Prefer waiting for P2 over authoring filler. Re-audit deferred refs only if a new merge lands.
+
+## Artifacts
+- PR: https://github.com/Geonhee-LEE/Representation-Aware-MPPI/pull/56
+- Files touched: docs/decisions.md, docs/deliberations.md, docs/p5_risk_calibration_harness.md, results/p5-promote-d015-q013-deferred-refs.tsv
+- TSV row appended: yes

--- a/results/p5-promote-d015-q013-deferred-refs.tsv
+++ b/results/p5-promote-d015-q013-deferred-refs.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-06-29T23:05:11+09:00	pending	qual:doc-only	keep	Promote deferred D-015 (calib-harness owner) + Q-013 (sweep strategy) into canonical logs; mark harness doc refs promoted


### PR DESCRIPTION
## Summary
- The 06-27 cycle (#55) recorded the **P5 risk-calibration harness ownership** decision (→D-015) and its **sweep-strategy open question** (→Q-013) *inline* in `docs/p5_risk_calibration_harness.md`, deferring the `decisions.md`/`deliberations.md` prepends to dodge the D-011 conflict trap (open #55 held those files).
- #55 is now merged and the four remaining open PRs are all P2 build-path with **no contention** on the canonical logs (verified via `gh pr view --json files`), so this promotes both:
  - **D-015** — one harness `eval/calibrate_risk.py` owns the joint `(k,δ)` sweep (refs frozen; baseline `k=0` reproduces no-critic numbers; per-scenario Pareto front).
  - **Q-013** — sweep strategy: 2-D `(k,δ)` plane vs full grid vs coordinate-descent.
- Marks the harness doc's two pending-promotion notes as resolved; restores the design-lane audit trail (D-008's purpose: canonical log, not decisions buried in a spec doc).

## Test plan
- [x] Doc-only change → no `src/` touched, no build smoke needed
- [x] `D-015`/`Q-013` present exactly once in the canonical logs; no remaining `(→D-015)`/`(→Q-013)`/`pending promotion` markers outside D-015's own historical-context line
- [x] No snapshot files (`STATE`/`JOURNAL`/`RESULTS.md`) staged on branch (D-011)

## Closes
- TODO: P3/P5 dangling-ref audit (STATE `Next claude-actionable` #1) — authored this cycle; Notion MCP unavailable in this cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)