### PR TITLE
[auto] P3 epistemic response-mode open question (margin vs active-perception)

### DIFF
--- a/docs/margin_inflation_cost_critic_interface.md
+++ b/docs/margin_inflation_cost_critic_interface.md
@@ -161,4 +161,28 @@ The implementing PR (post-#44, post-ensemble, post-stack-render) should satisfy:
   equal for a circular footprint but diverge once `CostCritic.consider_footprint: true`
   (currently `false`). Defer the polygon-footprint case to whenever footprint-aware costing
   is turned on; the circular-clearance form is the shipping default. Logged as O-1 here.
+- **O-2 — is margin-inflation the right *response mode* for the epistemic channel at all?**
+  This doc, §5, and the stack §4 fix that epistemic ≠ aleatoric *routing*, then assume the
+  epistemic response **is** a passive back-off (widen clearance by `k·σ` where the learned
+  model is ignorant). But epistemic uncertainty is by definition **reducible by sensing /
+  replanning / data** — so the distinctive correct response to it may be to *actively reduce*
+  it, not just stand further back. Four independent 2026-06-29 feed entries converge on this
+  fork and it is **not** yet captured in the design: **TRIAGE** (arXiv 2603.08128) makes the
+  routing-by-dominant-type principle explicit — epistemic-dominated risk should drive
+  *information-gathering / conservative replanning*, aleatoric-dominated risk a
+  disturbance-margin; **PA-MPPI** (2509.14978) is the executable form — a *perception cost
+  term inside MPPI* that biases rollouts toward poses which observe the unobserved (the
+  active half our unobserved-mask, §3, only marks passively); **the GP-contraction-tube MPC**
+  (2507.02098) offers a *principled* epistemic-σ→margin map (a contraction-bounded reachable
+  tube) as the disciplined alternative to a hand-set `k` multiplier; **BC-MPPI** (2510.00272)
+  is the in-sampler aleatoric sibling (a learned feasibility-probability reweight toward a
+  prescribed violation rate). The open question: **does the epistemic channel warrant a
+  *second* response term (info-gather / active-perception cost, à la PA-MPPI) in addition to
+  — or instead of — the §2 `k·σ` margin, and is the tube (2507.02098) a better σ→margin map
+  than a swept scalar `k`?** This is a P3-design / P5-ablation fork (margin-only vs
+  margin+active-perception vs tube-margin), distinct from Q-008 which only asks the *value*
+  of `k` under the margin-only assumption. **Deferred as Q-014** — to be prepended to
+  `deliberations.md` once PR #56 (currently editing that file with Q-013/D-015) merges, per
+  the D-011 same-file-prepend-collision avoidance the 06-27→06-29 deferred-ref cycle
+  established. Logged inline here as O-2 until promoted.
 </content>

--- a/journal/2026-06/30-00-p3-epistemic-response-mode-question.md
+++ b/journal/2026-06/30-00-p3-epistemic-response-mode-question.md
@@ -1,0 +1,35 @@
+# P3 epistemic response-mode open question (margin vs active-perception)
+
+- **Cycle**: 2026-06-30 00:00 KST
+- **Branch**: `autoresearch/p3-epistemic-response-mode-question`
+- **TODO**: feed-driven (Notion unreachable this cycle — gate 2/4 read from STATE instead)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- STATE declared the build lane fully P2-blocked and the doc lane "exhausted", recommending a `plan-no-fit` skip. But Phase 0 surfaced **four** independent 2026-06-29 feed entries converging on one design fork the spec'd P3 epistemic critic does not consider.
+- Recorded that fork as **O-2 / deferred Q-014** in the *uncontended* `docs/margin_inflation_cost_critic_interface.md` §7 — conflict-free with the open PRs (#56 owns `deliberations.md`/`decisions.md`; the P2 cluster owns `learning/`/`data_pipeline/`).
+- Deferred the `Q-014` deliberations.md promotion inline (D-011 same-file-prepend trap), mirroring the proven 06-27→06-29 deferred-ref pattern.
+
+## What worked / what failed
+- **Worked**: found a genuinely conflict-free, non-filler design-lane edit even with 5 PRs in queue — the critic interface docs are owned by no open PR.
+- **Worked**: the fork is real, not invented — the current design (§5) only splits epistemic-*routing* from aleatoric; it silently assumes the epistemic *response* is passive `k·σ` margin. TRIAGE/PA-MPPI say epistemic risk (reducible by sensing) may warrant *active* info-gathering instead.
+- **Failed/limited**: Notion MCP was not permission-granted this non-interactive run, so gates 2 (stuck-TODO) and 4 (empty-backlog) were evaluated from STATE.md, and no Notion bookkeeping (Phase 5a–5d) could be written. Logged here instead.
+
+## North-star delta
+- No measured numbers (still 0; gated on P2 + the user-owned `cafe-001.json` run).
+- + 1 design fork captured before implementation: when P2 lands and the epistemic critic is built, the implementer now has the explicit margin-only-vs-margin+active-perception-vs-tube-margin choice on record, with 4 citations, instead of silently defaulting to margin-only.
+
+## Key learnings
+- "Doc lane exhausted" (STATE) is conditional on *no fresh input* — a same-day feed convergence re-opens genuine design-lane value even when the build lane is blocked. Phase 0's literature pre-emption is exactly for this; it overrode a stale-by-1-hour skip recommendation.
+- The contended-file map matters: with 5 open PRs, the conflict-free surface is precisely the docs no open PR touches. Check `gh pr view --json files` before picking a doc target.
+
+## Recommended next 1–3 priorities
+1. **(user)** Merge the P2 build-path cluster #44→#45→#23→#24 — still the sole gate on every downstream P3 step.
+2. After #56 merges, promote **Q-014** (epistemic response-mode) from this doc's §7 into `deliberations.md`, alongside re-checking other deferred refs.
+3. When the epistemic critic is implemented (post-P2), make the active-perception term a P5 ablation arm (margin-only vs margin+PA-MPPI-cost vs contraction-tube margin), not a hidden default.
+
+## Artifacts
+- PR: https://github.com/Geonhee-LEE/Representation-Aware-MPPI/pull/57
+- Files touched: docs/margin_inflation_cost_critic_interface.md, results/p3-epistemic-response-mode-question.tsv
+- TSV row appended: yes

--- a/results/p3-epistemic-response-mode-question.tsv
+++ b/results/p3-epistemic-response-mode-question.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-06-30T00:04:21+09:00	ccf957b	qual:doc-only	keep	Record epistemic response-mode fork (margin vs active-perception) as O-2/Q-014 from 06-29 feed convergence


### PR DESCRIPTION
## Summary
- Records **O-2 / deferred Q-014** in `docs/margin_inflation_cost_critic_interface.md` §7: the spec'd epistemic critic assumes the epistemic response **is** passive `k·σ` margin inflation, but four independent 2026-06-29 feed entries converge on a fork it doesn't consider — epistemic uncertainty is *reducible by sensing*, so the response may warrant an **info-gather / active-perception** term, not only a back-off margin.
- Cites the convergence: **TRIAGE** (2603.08128, routing-by-type), **PA-MPPI** (2509.14978, perception cost inside MPPI), **GP-contraction-tube MPC** (2507.02098, principled σ→margin map), **BC-MPPI** (2510.00272, aleatoric in-sampler sibling).
- Q deferred inline (Q-014) to avoid the D-011 same-file-prepend collision with open PR #56 (which edits `deliberations.md`); promote after #56 merges. Doc-only, conflict-free, zero build-path code.

## Test plan
- [x] Doc-only change → no `src/` touched, no build smoke needed
- [x] No snapshot files (STATE/JOURNAL/RESULTS) staged on branch (D-011)
- [x] Only `docs/` + unique-path `results/*.tsv` in the diff

## Closes
- Feed-driven design-lane item (Notion unreachable this cycle; logged in journal). Distinct from Q-008 (the `k` *value*) — this asks whether margin-inflation is the right epistemic *response mode* at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)