### PR TITLE
[auto] Promote Q-014 (epistemic response-mode fork) to deliberations.md

### DIFF
--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -11,6 +11,16 @@
 
 ---
 
+## Q-014 — 2026-07-02 — `[uncertainty]` epistemic 채널의 *response mode*: passive `k·σ` margin 만인가, active-perception / tube 도 필요한가
+
+- **Question**: 설계(§5, stack §4, margin critic §2)는 epistemic vs aleatoric 를 *routing* 으로만 가르고, epistemic 의 *response* 는 암묵적으로 passive back-off (`k·σ` 로 clearance 확대)라 가정한다. 그러나 epistemic uncertainty 는 정의상 **sensing / replanning / data 로 감소 가능** — 그래서 올바른 대응은 물러서기가 아니라 *능동적으로 줄이기* 일 수 있다. epistemic 채널이 `k·σ` margin 에 **더해 (또는 대신)** 두 번째 response term (info-gather / active-perception cost) 을 가져야 하나, 그리고 tube 가 swept scalar `k` 보다 나은 σ→margin map 인가.
+- **Trade-off**:
+  - **margin-only (`k·σ`)**: 단순, `k=0`⇒baseline 깔끔한 ablation, 구현 최소. 그러나 epistemic 의 reducible 성질을 안 씀 — 미관측 영역을 계속 회피만 하고 관측하러 안 감.
+  - **+ active-perception term (PA-MPPI 2509.14978)**: rollout 을 미관측 pose 관측 쪽으로 bias — unobserved-mask(§3)의 능동 짝. 그러나 새 cost term + weight knob, MPPI objective 복잡화.
+  - **tube-margin (GP-contraction-tube 2507.02098)**: hand-set `k` 대신 contraction-bounded reachable tube 로 σ→margin 을 *원리적으로* 매핑. 그러나 contraction metric 추정 필요, 무거움.
+- **Lean**: shipping default 는 margin-only (`k·σ`, D-013 critic) 유지 — 깔끔한 ablation baseline 이 먼저. active-perception / tube 는 **P3-design / P5-ablation fork** 로 둔다 (margin-only vs margin+active-perception vs tube-margin 3-way). Q-008(margin `k` 의 *value*)과 구별됨 — 이건 response *mode* 자체를 물음. 근거: 2026-06-29 feed 4건 수렴 (TRIAGE 2603.08128 routing-by-dominant-type, PA-MPPI 2509.14978 in-sampler perception cost, GP-contraction-tube 2507.02098, BC-MPPI 2510.00272 aleatoric 짝).
+- **다음 action**: P2 ensemble land + P3 critic 구현 후 baseline `k·σ` 먼저 세우고, P5 harness 에서 3-way ablation 추가. resolve 시 D-MMM. ref: [`margin_inflation_cost_critic_interface.md`](margin_inflation_cost_critic_interface.md) §7 (O-2 원문), [`residual_in_rollout_reference.md`](residual_in_rollout_reference.md).
+
 ## Q-013 — 2026-06-29 — `[uncertainty]` coupled knob-vector 의 sweep 전략: 2-D `(k,δ)` plane vs full grid vs coordinate-descent
 
 - **Question**: D-015 의 calibration harness 가 5 knob (`k`/`δ`/`α`/`σ²_ref`/`σ²_ref_ale`) 을 어떤 전략으로 sweep 하나. full 5-D grid (기각, combinatorial) vs **2-D `(k,δ)` plane + refs frozen** (harness 문서 default) vs coordinate-descent (저렴하나 `k`↔`σ²_ref` 결합 valley 에서 stall).

--- a/docs/margin_inflation_cost_critic_interface.md
+++ b/docs/margin_inflation_cost_critic_interface.md
@@ -181,8 +181,8 @@ The implementing PR (post-#44, post-ensemble, post-stack-render) should satisfy:
   — or instead of — the §2 `k·σ` margin, and is the tube (2507.02098) a better σ→margin map
   than a swept scalar `k`?** This is a P3-design / P5-ablation fork (margin-only vs
   margin+active-perception vs tube-margin), distinct from Q-008 which only asks the *value*
-  of `k` under the margin-only assumption. **Deferred as Q-014** — to be prepended to
-  `deliberations.md` once PR #56 (currently editing that file with Q-013/D-015) merges, per
-  the D-011 same-file-prepend-collision avoidance the 06-27→06-29 deferred-ref cycle
-  established. Logged inline here as O-2 until promoted.
+  of `k` under the margin-only assumption. **Promoted to `deliberations.md` Q-014**
+  (2026-07-02, once PR #56's Q-013/D-015 edits landed on main and cleared the D-011
+  same-file-prepend collision). This §7 O-2 block stays the canonical *rationale*; Q-014 is
+  the tracked open-question stub — resolve there when the P5 3-way ablation runs.
 </content>

--- a/journal/2026-07/02-23-p3-promote-q014-epistemic-response-mode.md
+++ b/journal/2026-07/02-23-p3-promote-q014-epistemic-response-mode.md
@@ -1,0 +1,51 @@
+# Promote Q-014 (epistemic response-mode fork) to deliberations.md
+
+- **Cycle**: 2026-07-02 23:00 KST
+- **Branch**: `autoresearch/p3-promote-q014-epistemic-response-mode`
+- **TODO**: doc-lane deferred-ref cleanup (STATE re-open condition (a): a merge landed)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- Promoted the **O-2 fork** (is passive `k·σ` margin the right *response mode* for the
+  epistemic channel, or does it need an active-perception / tube term?) from inline-only in
+  `margin_inflation_cost_critic_interface.md` §7 to a canonical **Q-014** stub at the top of
+  `deliberations.md`.
+- Updated the margin-doc §7 note from "Deferred as Q-014 — to be prepended once #56 merges"
+  → "Promoted to `deliberations.md` Q-014"; the §7 O-2 block stays the canonical rationale.
+
+## What worked / what failed
+- **Queue-race caught (again).** Pre-fetch snapshot read queue=6 (would `pr-queue-full` skip);
+  a fresh fetch showed #56 **and** #57 both merged at the 23:00 co-fire → true queue=4. The
+  06-29 learning ("recompute after fetch before trusting a skip") paid off directly this cycle.
+- **The deferred ref was real, not filler.** #56's merge cleared the exact D-011 same-file
+  collision that forced Q-014 inline-only; leaving it would have left the deliberation log
+  missing a logged open question two design docs forward-reference.
+- Clean doc-only diff (+14/-4 across 2 files); no snapshot-file leak; PR #58 opened.
+
+## North-star delta
+- No motion toward first numbers — still 0 measured, P2-gated. This is design-record hygiene.
+- Design coherence +1: the epistemic response-mode fork is now a tracked Q, not a dangling
+  inline note — the P5 ablation matrix (margin-only vs +active-perception vs tube) is now
+  discoverable from the canonical deliberation log.
+
+## Key learnings
+- The "doc lane exhausted" STATE claim keeps being **conditional on no fresh input** — a merge
+  (not just a new feed entry) re-opens conflict-free deferred-ref work. This is the 3rd cycle
+  where a co-fire merge unblocked a same-file-deferred prepend; the D-011 defer→promote pattern
+  is now a recurring, predictable lane.
+- After this promotion the doc lane is **genuinely thin again** — no further deferred refs are
+  outstanding (D-015/Q-013 done via #56, Q-014 done here). Next value is P2-merge-gated.
+
+## Recommended next 1–3 priorities
+1. (user) Merge the P2 build-path cluster #44 (keystone) → #45 → #23 → #24 — the sole gate on
+   ALL P3 code (ensemble → renderers → `[5,H,W]` stack → both risk critics → calib harness).
+2. (claude) Prefer an honest `plan-no-fit` skip over filler until a P2 PR merges OR a new
+   same-day feed convergence surfaces an uncovered fork.
+3. (claude, when P3 code unblocks) Implement the margin-only `RiskInflationCritic` baseline
+   first (D-013) so Q-014's 3-way ablation has a `k=0` reference arm.
+
+## Artifacts
+- PR: https://github.com/Geonhee-LEE/Representation-Aware-MPPI/pull/58 (autoresearch/p3-promote-q014-epistemic-response-mode)
+- Files touched: docs/deliberations.md, docs/margin_inflation_cost_critic_interface.md
+- TSV row appended: yes

--- a/results/p3-promote-q014-epistemic-response-mode.tsv
+++ b/results/p3-promote-q014-epistemic-response-mode.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-02T23:03:26+09:00	382af84	qual:doc-only	keep	Promote O-2/Q-014 epistemic response-mode fork inline->deliberations.md; margin doc note updated


### PR DESCRIPTION
## Summary
- Promote the **O-2 fork** — *is passive `k·σ` margin the right response mode for the epistemic channel, or does it warrant an active-perception / tube term?* — from inline-only in `margin_inflation_cost_critic_interface.md` §7 to a canonical **Q-014** stub at the top of `deliberations.md`.
- The inline O-2 was deferred pending PR #56's Q-013/D-015 edits to `deliberations.md` (D-011 same-file-prepend-collision avoidance). **#56 merged at the 2026-07-02 23:00 KST co-fire**, clearing the trap — this promotes the dangling ref, exactly as the 06-30 journal flagged ("after #56 merges, promote Q-014").
- Margin-doc §7 note updated from "Deferred as Q-014 — to be prepended…" → "Promoted to `deliberations.md` Q-014"; the §7 O-2 block stays the canonical rationale, Q-014 is the tracked stub.
- Q-014 records the 3-way P3-design / P5-ablation fork (margin-only vs margin+active-perception vs tube-margin), distinct from Q-008 (value of `k`). Lean: ship margin-only baseline first, add active-perception/tube as a P5 ablation.

## Test plan
- [x] Doc-only change → `## Q-014` present above `## Q-013`; margin §7 note updated; no `src/` touched
- [x] No snapshot files (`STATE`/`JOURNAL`/`RESULTS.md`) staged on branch (D-011)

## Closes
- Doc-lane deferred-ref cleanup (STATE re-open condition (a): a merge landed). No Notion TODO id — Notion MCP unauthenticated this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)