### PR TITLE
[auto] Record σ-calibration-quality axis fork (deferred Q-015) in P5 harness

### DIFF
--- a/docs/p5_risk_calibration_harness.md
+++ b/docs/p5_risk_calibration_harness.md
@@ -122,6 +122,65 @@ obstacle classes (`straight`, `obstacle_crossing`, `head_on`, `cut_in`, `convoy`
 across all scenarios** so a config can't overfit one map; the per-scenario rows make
 env-specific divergence visible (a `k` good for `cafe` may over-detour in `small_city`).
 
+## 3½. The uncovered axis — is the σ we tune *against* itself calibrated? (deferred Q-015)
+
+Every knob in §2 is a **consumer** of the ensemble/predictor σ: `k·σ`, `z(δ)·σ_ale`,
+and the two `σ²_ref` scales all assume the σ handed up from P2 (or a downstream
+pedestrian-covariance predictor at P4) is a **trustworthy** number whose reported spread
+matches empirical coverage. The metric vector in §3 scores only **downstream outcomes**
+(near-miss, time-to-goal, cte, jerk) — it never asks whether that σ's stated confidence is
+*true*. If σ is mis-calibrated (a Gaussian head that says "68%" but actually covers 50%),
+the whole `(k, δ)` sweep silently absorbs the miscalibration into the gain: the harness
+finds a `k` that *compensates* for a bad σ on one scenario and mis-generalizes on the next,
+and the frozen config is uninterpretable (is `k=1.3` because the geometry needs it, or
+because σ was 1.3× under-confident?). Four independent 2026-07-02 feed entries converge on
+exactly this gap from different function classes:
+
+- **Rethinking-Gaussian** (`arxiv:2603.10407`) — recalibrate a *parametric* Gaussian
+  predictor upstream (KDE-of-confidence → Chi-squared matching loss) **before** the
+  chance term consumes its covariance; score reliability/ECE as its own metric.
+- **OCULAR** (`arxiv:2605.13028`, WAFR 2026) — *perception-conditioned, per-cell* conformal
+  calibration of dynamics σ from BEV/semantic features, with a coverage guarantee that
+  varies with what the representation sees (a direct P2→P3 handoff: turn the ensemble σ
+  into a guaranteed *local* set, not a homogeneous one).
+- **Scenario-aware UQ** (`arxiv:2512.05682`) — *distribution-free* conformal intervals on
+  the predictor output + a reliable/unreliable **segmentation** so only the untrustworthy
+  horizon tail is inflated, not the whole tube.
+- **How-Human-Motion-Prediction-Quality** (`arxiv:2601.09856`, 80-subject study) —
+  eval-honesty: rank any σ-emitting forecaster on **closed-loop + human-comfort** outcomes,
+  never on ADE/FDE (mean-accuracy) alone; calibration ≠ accuracy.
+
+**The fork this opens (Q-015).** Does the calibration harness need a **σ-calibration
+stage + a calibration-quality metric axis** *upstream* of the §2 gain sweep, or does the
+`(k, δ)` gain sweep alone suffice by absorbing miscalibration into the gain? If a stage is
+warranted, three sub-options mirror the feed's function classes: (a) **parametric
+recalibration** (Rethinking-Gaussian) — cheapest, but assumes a Gaussian head; (b)
+**global conformal** coverage set — distribution-free, one quantile for the whole field;
+(c) **perception-conditioned local conformal** (OCULAR) — per-cell, matches the core
+representation hypothesis but needs a BEV-feature similarity metric and drops the
+linear-Gaussian proof for our nonlinear residual+ensemble. And the metric side: add
+**reliability-diagram / ECE / interval-coverage** as a *scored calibration axis* alongside
+(near-miss, time-to-goal) in §3, so the harness reports "is σ calibrated *here*" separately
+from "did the gain avoid the obstacle."
+
+**Why this is distinct from Q-013 and D-015.** Q-013 asks *how to sweep* the consumer gains
+(2-D plane vs full grid); D-015 assigns *one owner* to that sweep. Neither questions whether
+the σ being consumed is calibrated at all — both treat σ as a given input. Q-015 sits
+**upstream** of both: it is about validating/calibrating the *input* to the sweep, and about
+adding a calibration-quality *metric* the sweep currently lacks.
+
+> **Deferred (D-011 same-file trap).** This fork belongs in `deliberations.md` as **Q-015**,
+> but PR #58 currently holds a pending prepend of Q-014 to that file — prepending Q-015 on a
+> branch off main would collide with #58 at the file head (the exact conflict D-011 forbids
+> re-introducing). Recorded here inline; a future cycle promotes it to a canonical **Q-015**
+> stub once #58 merges and `deliberations.md` is conflict-free again (same defer→promote
+> pattern used for Q-013/Q-014). **Lean**: a stage *is* warranted at P4 (pedestrian covariance
+> is where miscalibration bites hardest), start with **(a) parametric recalibration** as the
+> cheapest first cut and add the **ECE/coverage metric axis to §3 immediately** (it needs no
+> new σ source — it scores whatever σ the ensemble already emits). **Next action**: a P5/P4
+> cycle resolves against the first measured (k,δ) front — does a recalibrated σ move the
+> Pareto front, or does the gain already absorb it? — then promotes to a D-NNN.
+
 ## 4. What stays out of scope (v0)
 
 - **No online tuning, no learning the knobs** — offline batch sweep → frozen config only.
@@ -165,4 +224,4 @@ _Cross-refs: [`run_metrics.md`](run_metrics.md) · [`path_tracking_metrics.md`](
 [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md) ·
 [`multi_channel_risk_bev_stack.md`](multi_channel_risk_bev_stack.md) ·
 [`decisions.md`](decisions.md) D-009/D-013/D-014/**D-015** ·
-[`deliberations.md`](deliberations.md) Q-008/Q-009/Q-011/Q-012/**Q-013**._
+[`deliberations.md`](deliberations.md) Q-008/Q-009/Q-011/Q-012/**Q-013** (+ **Q-015** deferred inline §3½ — σ-calibration axis, promote once #58 merges)._

--- a/journal/2026-07/03-00-p3-sigma-calibration-quality-axis.md
+++ b/journal/2026-07/03-00-p3-sigma-calibration-quality-axis.md
@@ -1,0 +1,54 @@
+# P3→P5: record the σ-calibration-quality axis fork (deferred Q-015)
+
+- **Cycle**: 2026-07-03 00:00 KST
+- **Branch**: `autoresearch/p3-sigma-calibration-quality-axis`
+- **TODO**: `p3-sigma-calib` (authored this cycle — no Notion, unauthenticated)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- Phase-0 scan surfaced a **4-entry same-day (2026-07-02) feed convergence** on one
+  uncovered fork: the σ/covariance the risk margins consume must itself be *calibrated*,
+  and calibration quality is its own metric — Rethinking-Gaussian (`2603.10407`), OCULAR
+  (`2605.13028`), Scenario-aware UQ (`2512.05682`), How-Human-Motion (`2601.09856`).
+- Verified the gap is real: `p5_risk_calibration_harness.md` §2 sweeps σ-*consumer* gains
+  (`k`/`δ`/`α`/`σ²_ref`) and §3's metric vector scores only downstream outcomes
+  (near-miss, time-to-goal, cte, jerk) — no ECE/reliability/coverage axis, and §4 excludes
+  only the `σ²_ref` *scale*, not σ-trustworthiness.
+- Recorded it as harness **§3½ + deferred Q-015**; deferred the `deliberations.md` prepend
+  (D-011 trap — #58 owns a pending Q-014 prepend). Doc-only, +60/-1.
+
+## What worked / what failed
+- Re-open condition (b) fired cleanly: STATE (07-02 23:00) declared the *deferred-ref* lane
+  exhausted, but its Phase-0 that cycle picked the deferred Q-014 and never scanned fresh
+  feed for **new** forks — so this convergence was genuinely unclaimed, not filler.
+- Confirmed Q-015 is orthogonal to Q-013/D-015: those are *how-to-sweep* / *who-owns-sweep*
+  of the consumer gains; Q-015 is **upstream** — is the σ input trustworthy + does §3 need a
+  calibration metric. No overlap, so it earns its own Q.
+- Notion MCP unauthenticated again (gates 2/4 + Phase 5 reconcile from STATE, per precedent).
+
+## North-star delta
+- No measured numbers (still 0 — gated on P2). Pure design-lane motion: +1 P3→P5 design
+  fork recorded, closing a real hole in the harness spec (it would have silently absorbed σ
+  miscalibration into `k` and mis-generalized across scenarios).
+
+## Key learnings
+- "Doc lane exhausted" is scoped to *deferred refs*, not to *fresh-feed forks*: a Phase-0
+  convergence can re-open genuine design work even when every prior deferred ref is cleared
+  and the build lane is blocked. The exhaustion claim must be re-tested against Phase-0 each
+  cycle, not inherited from STATE.
+- The defer→promote (D-011) lane now has **two** items queued behind #58: Q-014 (its own
+  content) and Q-015 (this cycle, inline in the harness doc). When #58 merges, one cycle can
+  promote Q-015 to `deliberations.md`.
+
+## Recommended next 1–3 priorities
+1. (user) Merge P2 build-path cluster #44→#45→#23→#24 — still the sole gate on all P3 code.
+2. Once #58 merges: promote Q-015 (σ-calibration-quality axis) to a canonical
+   `deliberations.md` stub + mark the §3½ note "Promoted".
+3. If a P2 PR merges: the §3½ **ECE/coverage metric axis** needs no new σ source — it can be
+   added to the harness §3 table immediately as the first concrete calibration-metric step.
+
+## Artifacts
+- PR: #59 (autoresearch/p3-sigma-calibration-quality-axis)
+- Files touched: docs/p5_risk_calibration_harness.md, results/p3-sigma-calibration-quality-axis.tsv
+- TSV row appended: yes

--- a/results/p3-sigma-calibration-quality-axis.tsv
+++ b/results/p3-sigma-calibration-quality-axis.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-03T00:04:07+09:00	822e508	qual:doc-only	keep	Record deferred Q-015: sigma-calibration-quality axis gap in P5 harness (4-entry 07-02 feed convergence)


### PR DESCRIPTION
## Summary
- The P5 risk-calibration harness (`docs/p5_risk_calibration_harness.md`) sweeps the σ-**consumer** gains (`k`, `δ`, `α`, `σ²_ref`) but never validates that σ itself is calibrated, and its §3 metric vector has **no calibration-quality axis** (ECE / reliability / coverage). Four independent 2026-07-02 feed entries converge on this gap from different function classes: Rethinking-Gaussian (`2603.10407`, parametric recalibration), OCULAR (`2605.13028`, perception-conditioned local conformal), Scenario-aware UQ (`2512.05682`, distribution-free conformal + reliable/unreliable segmentation), How-Human-Motion (`2601.09856`, calibration ≠ ADE accuracy).
- Recorded as harness **§3½ + deferred Q-015**. Distinct from Q-013 (*how* to sweep the gains) and D-015 (*who owns* the sweep): Q-015 is **upstream** of both — is the σ being consumed trustworthy at all, and does §3 need an ECE/coverage metric.
- **Deliberations.md prepend deferred** (D-011 same-file trap): PR #58 holds a pending Q-014 prepend; a Q-015 prepend on a branch off main would collide at the file head. A future cycle promotes Q-015 to a canonical stub once #58 merges — same defer→promote pattern used for Q-013/Q-014.

## Test plan
- [x] Doc-only change → section headers parse (`## 3½.`, `## 4.` present), cross-refs updated
- [x] No `src/` touched → no build smoke needed
- [x] No snapshot files (`STATE`/`JOURNAL`/`RESULTS`.md) staged on branch (D-011 guard passed)

## Closes
- Design-lane fork surfaced by Phase-0 feed convergence (no Notion TODO — Notion MCP unauthenticated this run). Promotion to Q-015 tracked as a follow-up once #58 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)