### PR TITLE
[auto] Promote Q-015 (σ-calibration-quality axis) to deliberations.md

### DIFF
--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -11,6 +11,17 @@
 
 ---
 
+## Q-015 — 2026-07-05 — `[uncertainty]` P5 harness σ-calibration-quality 축: 소비자 gain sweep 전에 σ 자체가 calibrated 인가를 검증·metric 화해야 하나
+
+- **Question**: §2 의 모든 gain (`k·σ`, `z(δ)·σ_ale`, `σ²_ref`) 은 upstream σ 가 신뢰할 수 있다고 가정한다. §3 metric 은 downstream 결과(near-miss, time-to-goal, cte)만 본다 — σ 의 stated coverage 가 empirical coverage 와 맞는지 않는다. σ 가 mis-calibrated 이면 `(k,δ)` sweep 은 miscalibration 을 gain 에 흡수해 scenario 간 mis-generalize 하고, frozen config 가 "geometry 필요" vs "σ 불신" 구분 불가. **harness 에 σ-calibration stage + calibration-quality metric axis (ECE / interval-coverage / reliability-diagram) 가 §2 gain sweep 의 *upstream* 으로 필요한가, 아니면 gain sweep 의 흡수로 충분한가?**
+- **Trade-off**:
+  - **gain sweep 이 흡수**: 구현 최소; 그러나 `k` 가 geometry vs σ 불신 구분 불가 → cross-scenario mis-generalization 위험
+  - **(a) parametric recalibration** (Rethinking-Gaussian `2603.10407`): 가장 저렴, Gaussian head 가정; §3 ECE axis 는 새 σ 소스 없이 즉시 추가 가능
+  - **(b) global conformal coverage** (Scenario-aware UQ `2512.05682`): distribution-free 1 quantile; local variation 무시
+  - **(c) perception-conditioned local conformal** (OCULAR `2605.13028`): per-cell BEV-feature 기반; 가장 강하나 non-linear residual+ensemble 에서 linear-Gaussian 가정 포기
+- **Lean**: stage warranted (P4 pedestrian covariance 가 miscalibration 가장 쉽게 물림). 시작 = **(a) parametric recalibration + §3 ECE/coverage metric axis** (새 σ 소스 없이 즉시 추가); local conformal (c) 는 P5 ablation fork (vs OCULAR).
+- **다음 action**: P4/P5 cycle 이 첫 `(k,δ)` Pareto front 대비 "recalibrated σ 가 front 를 움직이나?" 검증 → yes: D-MMM (stage 추가); no: D-MMM (gain 흡수 충분). 구별: Q-013 (sweep *전략*), D-015 (sweep *소유자*). ref: [`p5_risk_calibration_harness.md`](p5_risk_calibration_harness.md) §3½.
+
 ## Q-014 — 2026-07-02 — `[uncertainty]` epistemic 채널의 *response mode*: passive `k·σ` margin 만인가, active-perception / tube 도 필요한가
 
 - **Question**: 설계(§5, stack §4, margin critic §2)는 epistemic vs aleatoric 를 *routing* 으로만 가르고, epistemic 의 *response* 는 암묵적으로 passive back-off (`k·σ` 로 clearance 확대)라 가정한다. 그러나 epistemic uncertainty 는 정의상 **sensing / replanning / data 로 감소 가능** — 그래서 올바른 대응은 물러서기가 아니라 *능동적으로 줄이기* 일 수 있다. epistemic 채널이 `k·σ` margin 에 **더해 (또는 대신)** 두 번째 response term (info-gather / active-perception cost) 을 가져야 하나, 그리고 tube 가 swept scalar `k` 보다 나은 σ→margin map 인가.

--- a/docs/p5_risk_calibration_harness.md
+++ b/docs/p5_risk_calibration_harness.md
@@ -169,17 +169,9 @@ the σ being consumed is calibrated at all — both treat σ as a given input. Q
 **upstream** of both: it is about validating/calibrating the *input* to the sweep, and about
 adding a calibration-quality *metric* the sweep currently lacks.
 
-> **Deferred (D-011 same-file trap).** This fork belongs in `deliberations.md` as **Q-015**,
-> but PR #58 currently holds a pending prepend of Q-014 to that file — prepending Q-015 on a
-> branch off main would collide with #58 at the file head (the exact conflict D-011 forbids
-> re-introducing). Recorded here inline; a future cycle promotes it to a canonical **Q-015**
-> stub once #58 merges and `deliberations.md` is conflict-free again (same defer→promote
-> pattern used for Q-013/Q-014). **Lean**: a stage *is* warranted at P4 (pedestrian covariance
-> is where miscalibration bites hardest), start with **(a) parametric recalibration** as the
-> cheapest first cut and add the **ECE/coverage metric axis to §3 immediately** (it needs no
-> new σ source — it scores whatever σ the ensemble already emits). **Next action**: a P5/P4
-> cycle resolves against the first measured (k,δ) front — does a recalibrated σ move the
-> Pareto front, or does the gain already absorb it? — then promotes to a D-NNN.
+> **Promoted to [`deliberations.md`](deliberations.md) as Q-015 (2026-07-05, once #58 merged
+> and cleared the D-011 same-file trap).** Lean and next-action as above. The canonical stub
+> is the authoritative record; this §3½ is the inline context that motivated it.
 
 ## 4. What stays out of scope (v0)
 
@@ -224,4 +216,4 @@ _Cross-refs: [`run_metrics.md`](run_metrics.md) · [`path_tracking_metrics.md`](
 [`aleatoric_risk_cost_critic_interface.md`](aleatoric_risk_cost_critic_interface.md) ·
 [`multi_channel_risk_bev_stack.md`](multi_channel_risk_bev_stack.md) ·
 [`decisions.md`](decisions.md) D-009/D-013/D-014/**D-015** ·
-[`deliberations.md`](deliberations.md) Q-008/Q-009/Q-011/Q-012/**Q-013** (+ **Q-015** deferred inline §3½ — σ-calibration axis, promote once #58 merges)._
+[`deliberations.md`](deliberations.md) Q-008/Q-009/Q-011/Q-012/**Q-013**/**Q-015**._

--- a/results/p3-promote-q015-sigma-calibration-axis.tsv
+++ b/results/p3-promote-q015-sigma-calibration-axis.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-05T23:06:11+09:00	651fcaa	qual:doc-only	keep	Promote Q-015 (σ-calibration-quality axis) inline→canonical deliberations.md; update harness §3½ deferred note to promoted


### PR DESCRIPTION
## Summary
- Promotes deferred inline Q-015 from `docs/p5_risk_calibration_harness.md` §3½ to a canonical stub in `docs/deliberations.md`
- Q-015: does the P5 calibration harness need a σ-calibration-quality stage + ECE/coverage metric axis upstream of the gain sweep, or does `(k,δ)` absorption suffice?
- Updates harness §3½ deferred note to "Promoted" and fixes footer cross-ref to include Q-015

## Test plan
- [ ] Doc-only change → grep/parse check: `Q-015` appears in `deliberations.md` above Q-014
- [ ] Harness footer references `Q-015` without the old "(deferred inline)" annotation
- [ ] No snapshot files (`STATE.md`/`JOURNAL.md`/`RESULTS.md`) on this branch

## Closes
- Completes the D-011 defer→promote lane for Q-015, opened by the 2026-07-03 σ-calibration-quality-axis cycle (PR #59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)