### PR TITLE
[auto] Promote Q-016 (HOLO-MPPI prior interface) to deliberations.md

### DIFF
--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -11,6 +11,17 @@
 
 ---
 
+## Q-016 — 2026-07-08 — `[arch]` HOLO-MPPI prior interface: 학습된 sampling prior 는 어떤 representation 을 conditioning 입력으로 써야 하나
+
+- **Question**: HOLO-MPPI 패턴으로 offline-trained policy 가 nav2_mppi 의 sampling distribution parameters 를 출력할 때, 그 policy 의 observation input 을 (a) raw P1 BEV features 만 쓸지, (b) P2 latent / residual encoder output 을 쓸지, (c) 둘을 합칠지. 즉, sampling prior 가 *perception representation* 만 조건화되어야 하나 *dynamics latent* 까지 조건화되어야 하나.
+- **Trade-off**:
+  - **(a) P1 BEV only**: P2 독립 → prototype 지금 시작 가능, 학습 파이프라인 단순; 단, dynamics-regime 정보(venue-specific friction, speed profile) 가 prior 에 없어 cafñe → small_city 이동 시 covariance 적응 제한.
+  - **(b) P2 latent only**: dynamics context 풍부하나 #44 merge 전까지 blocked; BEV 시각 맥락 없이 latent 만 쓰면 obstacle geometry 정보 손실.
+  - **(c) both (fusion)**: 가장 완전하나 두 encoder 의 학습·inference pipeline 결합 → staging / dependency 복잡화; P5 ablation 전엔 (a) vs (c) contribution 분리 불가.
+- **Lean**: **(a) P1 BEV-only prior 먼저** — P2 독립, HOLO-MPPI 핵심 thesis ("representation drives sampler") 을 가장 빠르게 검증; (c) 는 P2 land 후 P4/P5 ablation fork (HOLO-MPPI-fused vs HOLO-MPPI-BEV-only). 근거: 현재 P2 stall 21일 — P2 gated 작업은 scheduling 열위, BEV-only prior 가 thesis 입증 선행 조건.
+- **다음 action**: P1 BEV feature extractor (semseg pretrained) prototype 후 `BEVConditionedPrior` 모듈 설계 → P2 land 시 (c) extension 분기. resolve 시 D-MMM. ref: [`research_feed_synthesis_2026_07_05.md`](research_feed_synthesis_2026_07_05.md) Entry 3 + 02:00 feed HOLO-MPPI [[2606.16480]].
+- **Status**: open
+
 ## Q-015 — 2026-07-05 — `[uncertainty]` P5 harness σ-calibration-quality 축: 소비자 gain sweep 전에 σ 자체가 calibrated 인가를 검증·metric 화해야 하나
 
 - **Question**: §2 의 모든 gain (`k·σ`, `z(δ)·σ_ale`, `σ²_ref`) 은 upstream σ 가 신뢰할 수 있다고 가정한다. §3 metric 은 downstream 결과(near-miss, time-to-goal, cte)만 본다 — σ 의 stated coverage 가 empirical coverage 와 맞는지 않는다. σ 가 mis-calibrated 이면 `(k,δ)` sweep 은 miscalibration 을 gain 에 흡수해 scenario 간 mis-generalize 하고, frozen config 가 "geometry 필요" vs "σ 불신" 구분 불가. **harness 에 σ-calibration stage + calibration-quality metric axis (ECE / interval-coverage / reliability-diagram) 가 §2 gain sweep 의 *upstream* 으로 필요한가, 아니면 gain sweep 의 흡수로 충분한가?**

--- a/results/p3-q016-holo-mppi-prior-interface.tsv
+++ b/results/p3-q016-holo-mppi-prior-interface.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-08T23:04:51+09:00	d80aafd	qual:doc-only	keep	Q-016 HOLO-MPPI prior interface added to deliberations.md — P1 BEV-only lean, P2-independent scheduling


### PR DESCRIPTION
## Summary
- Adds Q-016 to `docs/deliberations.md`: architectural open question on how the HOLO-MPPI learned sampling prior should be conditioned — P1 BEV features only (a), P2 dynamics latent only (b), or both (c)
- Lean recorded: (a) P1 BEV-only first, P2-independent — enables earliest prototype of the "representation-aware-proposal" thesis; upgrade to (c) after P2 lands
- Triggered by merge of PR #61 (research_feed_synthesis_2026_07_05.md), which explicitly deferred this Q-016 entry until #60 cleared `deliberations.md`

## Test plan
- [ ] Doc-only change — grep/parse check passes
- [ ] Q-016 appears at top of `docs/deliberations.md` (newest-first convention), above Q-015
- [ ] No regression in existing tests

## Closes
- Triggered by PR #61 feed synthesis trigger condition: "If #60 or #61 merge → promote Q-016 (HOLO-MPPI prior interface) to deliberations.md"

🤖 Generated with [Claude Code](https://claude.com/claude-code)