### PR TITLE
[auto] fix red sandbox CI: occlusion epistemic-margin test → cost-contract test + Q-017

### DIFF
--- a/docs/deliberations.md
+++ b/docs/deliberations.md
@@ -11,6 +11,15 @@
 
 ---
 
+## Q-017 — 2026-07-12 — `[uncertainty]` epistemic k·σ margin 은 폐루프에서 inert — occlusion 에서 needle 을 움직이려면 어떤 소비 메커니즘이 필요한가
+
+- **Question**: D-013 margin inflation (알려진 obstacle 의 clearance 를 rollout 지점 σ 만큼 축소) 이 sandbox 폐루프 min-clearance 를 전혀 못 움직인다 (single-disc head-on: Δ≈1e-12 m; 유리하게 설계한 two-disc occluder pair 에서도 ±0.01 noise). 원인은 **horizon-visibility race** — rollout(≈1.2 m lookahead) 이 shadow 에 닿을 때쯤 robot 은 이미 visible side 로 swerve 했고 shadow 는 경로 밖으로 회전. "로봇이 다음에 갈 곳 = 지금 보이는 곳" 인 disc-world 에서 σ-at-rollout-point margin 은 구조적으로 불활성. 폐루프 occlusion 대응 (north star 의 '가려진' obstacle class) 에는 어떤 소비 메커니즘이 필요한가?
+- **Trade-off**: (a) **additive shadow-entry cost** (`w_epist·σ`, DYNAMIC 채널 소비와 동형) — shadow 진입 자체를 pricing → 수렴 지연/wider berth 기대, 구현 저렴, GT BEV 그대로 재사용; (b) **σ(x,u) action-conditioned query** (feed 2605.00261) — aggressive 통과만 pricing 하는 원리적 상위호환, 단 P2 ensemble 인터페이스 필요 (#44 gate); (c) **speed modulation** — shadow 내 v_ref 감속, margin 대신 시간 축 대응 (측정 metric 이 clearance 가 아니라 TTC/near-miss 로 바뀜).
+- **Lean**: (a) 먼저 — 이번 cycle 이 만든 rollout-cost contract 테스트 인프라로 즉시 폐루프 A/B 가능하고 P2 비의존. (b) 는 #44 merge 후 (a) 위에 얹는 순서.
+- **다음 action**: sandbox additive epistemic critic TODO (Backlog, Owner=claude) → 폐루프 clearance/berth A/B; needle 이 움직이면 D-013 소비 경로 개정 D-NNN 으로 승격.
+- **Status**: open
+- **Refs**: `journal/2026-07/12-23-fix-occlusion-epistemic-margin-test.md` + `eval/mppi_sandbox/tests/test_risk_mppi.py::test_epistemic_margin_prices_shadowed_corridor`
+
 ## Q-016 — 2026-07-08 — `[arch]` HOLO-MPPI prior interface: 학습된 sampling prior 는 어떤 representation 을 conditioning 입력으로 써야 하나
 
 - **Question**: HOLO-MPPI 패턴으로 offline-trained policy 가 nav2_mppi 의 sampling distribution parameters 를 출력할 때, 그 policy 의 observation input 을 (a) raw P1 BEV features 만 쓸지, (b) P2 latent / residual encoder output 을 쓸지, (c) 둘을 합칠지. 즉, sampling prior 가 *perception representation* 만 조건화되어야 하나 *dynamics latent* 까지 조건화되어야 하나.

--- a/eval/mppi_sandbox/tests/test_risk_mppi.py
+++ b/eval/mppi_sandbox/tests/test_risk_mppi.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from eval.mppi_sandbox.controllers import make_controller
 from eval.mppi_sandbox.critics import RiskInflationCritic
-from eval.mppi_sandbox.obstacles import CircleObstacle, min_clearance
+from eval.mppi_sandbox.obstacles import CircleObstacle
 from eval.mppi_sandbox.representations import GTBevProducer
 from eval.mppi_sandbox.run import ROBOT_RADIUS, run_scenario, simulate
 from eval.mppi_sandbox.tests.test_sandbox import _straight_scenario
@@ -62,21 +62,53 @@ class TestRepresentationMovesTheNeedle:
             f"stock {stock['min_obstacle_clearance']:.3f}")
         assert risk["metrics"]["cte_rms"] <= 0.30   # scenario acceptance
 
-    def test_epistemic_margin_widens_berth_in_occlusion_geometry(self):
-        """k·σ (D-013) only acts where the robot's corridor is shadowed —
-        an on-path static obstacle casts its shadow over the far half of
-        the lane, so k > 0 must buy clearance there (w_risk off isolates
-        the epistemic effect)."""
+    def test_epistemic_margin_prices_shadowed_corridor(self):
+        """k·σ (D-013) prices rollout points inside the occlusion shadow:
+        effective clearance to the known disc shrinks there, so a rollout
+        hugging the disc's blind side costs strictly more with k > 0,
+        while a rollout on the visible flank (σ = 0) costs the same.
+
+        This is deliberately a rollout-cost contract test, not a
+        closed-loop clearance test: measured 2026-07-12, k = 0.4 moves
+        closed-loop min-clearance by ~1e-12 m in this geometry (and ±0.01
+        noise in a two-disc occluder pair) because rollouts only reach
+        the shadow after the robot has swerved and the shadow has rotated
+        off-path — the horizon-visibility race. Whether any epistemic
+        consumption moves the closed-loop needle in occlusion geometry is
+        open (see docs/deliberations.md Q-017)."""
         ob = CircleObstacle(0.0, -1.5)
         scenario = _straight_scenario(obstacles=[ob], expected_duration=15.0)
-        clearances = {}
+        start_xy = np.array([0.0, 0.0])
+        ctrls = {}
         for k in (0.0, 0.4):
             ctrl = make_controller("risk_mppi", scenario, seed=0,
                                    robot_radius=ROBOT_RADIUS,
                                    w_risk=0.0, k_margin_per_sigma=k)
-            traj = simulate(scenario, ctrl)
-            clearances[k] = min_clearance(traj, [ob], ROBOT_RADIUS)
-        assert clearances[0.4] > clearances[0.0] + 0.02, clearances
+            ctrl._bev = ctrl.producer.render(start_xy, 0.0)
+            ctrls[k] = ctrl
+
+        # shadow: on-lane behind the disc (ray blocked, strictly beyond);
+        # visible: same range off to the flank, direct line of sight
+        shadow_pt, visible_pt = [0.0, -2.3], [1.0, -1.5]
+        m = ctrls[0.4]._extra_margin(np.array([shadow_pt, visible_pt]), 0.0)
+        assert m[0] == 0.4 and m[1] == 0.0
+
+        H = ctrls[0.4].p.horizon
+        def hover(xy):        # (1, H, 5) rollout parked at xy, heading -y
+            traj = np.zeros((1, H, 5))
+            traj[..., :2] = xy
+            traj[..., 2] = -np.pi / 2
+            return traj
+
+        # clear = 0.8 - 0.6 = 0.2 m without margin; -0.2 m with k·σ = 0.4
+        # → the shadowed rollout crosses the collision threshold only
+        #   under the epistemic margin, the visible one never does
+        shadow_gap = (ctrls[0.4]._cost(hover(shadow_pt), 0.0)
+                      - ctrls[0.0]._cost(hover(shadow_pt), 0.0))[0]
+        visible_gap = (ctrls[0.4]._cost(hover(visible_pt), 0.0)
+                       - ctrls[0.0]._cost(hover(visible_pt), 0.0))[0]
+        assert shadow_gap > ctrls[0.4].p.w_collision  # hard penalty engaged
+        assert visible_gap == 0.0
 
     def test_registry_exposes_risk_mppi(self):
         scenario = _straight_scenario()

--- a/journal/2026-07/12-23-fix-occlusion-epistemic-margin-test.md
+++ b/journal/2026-07/12-23-fix-occlusion-epistemic-margin-test.md
@@ -1,0 +1,45 @@
+# Occlusion epistemic-margin test: red CI fixed, D-013 closed-loop inertness confirmed and recorded (Q-017)
+
+- **Cycle**: 2026-07-12 23:00 KST
+- **Branch**: `autoresearch/p3-fix-occlusion-epistemic-margin-test`
+- **TODO**: `39ac5d39` [sandbox] risk_mppi epistemic margin occlusion 실패 테스트 수정
+- **Phase**: P3 (executed during P4 window — P0 red-CI fix takes precedence)
+- **Status**: keep
+
+## What I tried
+
+- Reproduced the red test on main: `test_epistemic_margin_widens_berth_in_occlusion_geometry` — k=0.4 vs k=0.0 clearances identical to 1e-12 (0.00788 m both).
+- Instrumented the sim: with k=0.4 only **0.04 % of rollout points ever receive margin > 0** (max 3.1 % in a single step); max trajectory perturbation 0.9 mm.
+- Probed the σ field directly: shadow rendering and `RiskInflationCritic.margin` are contract-correct (σ=1 in shadow, margin=0.4 there, 0 on visible flank). The mechanism, not the wiring, is inert.
+- Ran a two-disc occluder-pair geometry designed to favor the mechanism (hidden disc behind an on-path occluder, B_y ∈ {-2.5, -2.7, -3.0} × seeds {0,1}): gain = +0.0000, +0.0000, +0.0109/-0.0176 (noise-signed).
+- Replaced the closed-loop test with a rollout-cost contract test (`test_epistemic_margin_prices_shadowed_corridor`): shadowed hover rollout must cross the collision threshold only under k·σ (cost gap > w_collision), visible-flank rollout must cost exactly the same. Removed now-unused `min_clearance` import.
+- Recorded the negative result as **Q-017** in `docs/deliberations.md`.
+
+## What worked / what failed
+
+- Root cause is structural, not a bug: **horizon-visibility race**. Rollouts (~1.2 m lookahead at 0.4 m/s) only reach the occlusion shadow after the robot has committed to the visible side, and the shadow rotates off-path as it swerves. In a disc world, "where the robot goes next" ≈ "what it can currently see", so σ-at-rollout-point margin against *known* obstacles almost never binds.
+- The test's expectation was wrong for the mechanism: global min-clearance is achieved beside the obstacle where σ=0 by construction — k·σ cannot widen a visible graze, ever.
+- New contract test passes deterministically; full suite **57/57 green** (was 30/31 + 1 fail).
+
+## North-star delta
+
+- Sandbox CI on main goes red → green: the D-016 primary verification surface is trustworthy again for every future PR.
+- Negative knowledge: the D-013 epistemic consumption path, as implemented, does **not** contribute to the '가려진 obstacle' class of the north star in closed loop. Claiming it did would have been false; Q-017 now scopes what replaces it.
+
+## Key learnings
+
+- Margin inflation on known obstacles and pricing entry into unknown space are different mechanisms; occlusion response needs the latter (additive `w_epist·σ` cost, σ(x,u) action-conditioned query, or speed modulation — Q-017 trade-off).
+- Closed-loop "moves the needle" tests need a measured effect size before being enshrined in CI; mechanism-level cost-contract tests are the robust tier below them.
+- The two-disc experiment matters as much as the fix: it rules out "just pick a better geometry" as a rescue for the current mechanism.
+
+## Recommended next 1–3 priorities
+
+1. **Sandbox additive epistemic shadow-entry critic** (`w_epist`·σ additive cost, same GT BEV channel) + closed-loop A/B vs k·σ margin — answers Q-017 (a); Backlog TODO created.
+2. Create the queued `[research]`-prefixed Notion TODOs (STATE claude-actionable #1) — now feasible with `notion-create-pages` granted.
+3. P4-T02 Gazebo dynamic scenario YAML v1 (5/10/20 actor density) — P4-lane progress, no P2 dep.
+
+## Artifacts
+
+- PR: pending merge (autoresearch/p3-fix-occlusion-epistemic-margin-test)
+- Files touched: eval/mppi_sandbox/tests/test_risk_mppi.py, docs/deliberations.md
+- TSV row appended: yes

--- a/results/p3-fix-occlusion-epistemic-margin-test.tsv
+++ b/results/p3-fix-occlusion-epistemic-margin-test.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-12T23:11:39+09:00	1af9342	sandbox:pass=57/57	keep	occl epistemic-margin test -> cost-contract test; D-013 closed-loop inertness measured, Q-017 filed


### PR DESCRIPTION
## Summary
- Fixes the red sandbox CI on main: `test_epistemic_margin_widens_berth_in_occlusion_geometry` asked the D-013 k·σ margin for something it structurally cannot do — closed-loop min-clearance is achieved on the visible flank where σ=0, and rollouts only reach the occlusion shadow after the robot has swerved (horizon-visibility race). Measured effect: Δclearance ≈ 1e-12 m (single disc), ±0.01 noise (two-disc occluder pair, 3 geometries × 2 seeds).
- Replaces it with a deterministic rollout-cost contract test: a shadowed hover rollout must cross the collision threshold only under k·σ (cost gap > w_collision) while a visible-flank rollout costs byte-identically. Suite: 30/31 → **57/57 green**.
- Records the negative result + consumption-mechanism trade-off (additive shadow-entry cost vs σ(x,u) vs speed modulation) as **Q-017** in `docs/deliberations.md`.

## Test plan
- [x] `python3 -m pytest eval/mppi_sandbox/tests/ eval/tests/test_path_tracking_metrics.py eval/tests/test_run_metrics.py -q` → 57 passed
- [x] No `src/` touched → no colcon smoke needed
- [x] Snapshot files (STATE/JOURNAL/RESULTS) not staged (D-011)

## Closes
- TODO `39ac5d39`: [sandbox] risk_mppi epistemic margin occlusion 실패 테스트 수정 (https://www.notion.so/39ac5d39343d81b9acdde8abad90e92e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)