### PR TITLE
[auto] P3 blind-corner occlusion scenario + sightline metric (Q-017 test-bed)

### DIFF
--- a/eval/mppi_sandbox/occlusion.py
+++ b/eval/mppi_sandbox/occlusion.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Occlusion metrics for blind-corner scenarios (Q-017 measurement surface).
+
+The DYNAMIC-channel critic's north-star delta was measured with
+`min_obstacle_clearance` (head-on: +>0.1 m). The EPISTEMIC channel needs its
+own scalar — clearance is oracle-blind to occlusion, so it cannot score
+"how blind was the approach." This module supplies two such scalars, both
+computed from an executed (T, 6) trajectory plus the ground-truth occluder
+set, via the same `GTBevProducer` occlusion model the critics consume:
+
+- `sightline_reveal(traj, obstacles, target)` — at what arclength / distance
+  does a hidden `target` point first enter line-of-sight? A cautious
+  (epistemic-aware) approach reveals the pocket *earlier* / from *farther*,
+  buying reaction distance. This is the headline blind-corner metric: it is
+  non-zero and path-dependent even for a smooth trajectory.
+
+- `occlusion_exposure(traj, obstacles, lookahead)` — mean epistemic σ of the
+  pose the robot is about to enter (a `lookahead`-metre probe along the
+  executed path), evaluated from the BEV rendered at the current pose. This
+  is the quantity `ShadowCostCritic` charges directly. Empirically it is
+  ~0 for a *smooth* oracle-baseline MPPI (the occluded region sits off to the
+  side of the forward path, not on it — the generalisation of the Q-017
+  redundancy finding), so it is reported mainly as a floor the shadow cost
+  must not raise, not as a gain axis.
+
+Both take the plain obstacle list so they work off any run without threading
+a producer through — a fresh `GTBevProducer` is built with the same defaults
+the sandbox controllers use.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .representations import GTBevProducer, RiskChannel
+
+
+def _producer(obstacles, sensing_range: float) -> GTBevProducer:
+    return GTBevProducer(obstacles, sensing_range=sensing_range)
+
+
+def _arclength(xy: np.ndarray) -> np.ndarray:
+    """(T,) cumulative arclength of an (T, 2) path, starting at 0."""
+    seg = np.linalg.norm(np.diff(xy, axis=0), axis=1)
+    return np.concatenate([[0.0], np.cumsum(seg)])
+
+
+def point_sigma(obstacles, robot_xy, t: float, point,
+                sensing_range: float = 5.0) -> float:
+    """Epistemic σ of a single world `point` as seen from `robot_xy` at t.
+
+    σ=1 → occluded or beyond range (unknown); σ=0 → observed. Uses the
+    pessimistic unobserved prior (D-012)."""
+    bev = _producer(obstacles, sensing_range).render(np.asarray(robot_xy, float), t)
+    return float(bev.sample(RiskChannel.EPISTEMIC, np.atleast_2d(point),
+                            unobserved_value=1.0)[0])
+
+
+def sightline_reveal(traj: np.ndarray, obstacles, target,
+                     sensing_range: float = 5.0,
+                     visible_sigma: float = 0.5) -> dict:
+    """When does `target` first become visible along the executed path?
+
+    Returns a dict:
+      - visible_from_start: bool — target already in sight at pose 0
+      - reveal_index:       int | None — first trajectory index with σ<thresh
+      - reveal_arclength:   float | None — arclength travelled at reveal
+      - reveal_distance:    float | None — robot→target distance at reveal
+      - total_arclength:    float — full path length
+      - reveal_fraction:    float | None — reveal_arclength / total_arclength
+
+    A never-revealed target yields None for the reveal_* fields. A *cautious*
+    approach should reveal the target at a smaller reveal_fraction and a
+    larger reveal_distance (more reaction room)."""
+    xy = traj[:, 1:3]
+    ts = traj[:, 0]
+    arc = _arclength(xy)
+    tgt = np.asarray(target, float)
+    prod = _producer(obstacles, sensing_range)
+
+    reveal_index = None
+    for i in range(len(xy)):
+        bev = prod.render(xy[i], ts[i])
+        sigma = float(bev.sample(RiskChannel.EPISTEMIC, tgt[None],
+                                 unobserved_value=1.0)[0])
+        if sigma < visible_sigma:
+            reveal_index = i
+            break
+
+    out = {
+        "visible_from_start": reveal_index == 0,
+        "reveal_index": reveal_index,
+        "total_arclength": float(arc[-1]),
+        "reveal_arclength": None,
+        "reveal_distance": None,
+        "reveal_fraction": None,
+    }
+    if reveal_index is not None:
+        out["reveal_arclength"] = float(arc[reveal_index])
+        out["reveal_distance"] = float(np.linalg.norm(xy[reveal_index] - tgt))
+        out["reveal_fraction"] = (float(arc[reveal_index] / arc[-1])
+                                  if arc[-1] > 0 else 0.0)
+    return out
+
+
+def occlusion_exposure(traj: np.ndarray, obstacles, lookahead: float = 0.6,
+                       sensing_range: float = 5.0) -> float:
+    """Mean epistemic σ of the pose `lookahead` m ahead along the executed
+    path, evaluated from the BEV at the current pose. Proxy for "driving
+    blind." ≥ 0; ~0 for a smooth oracle-baseline path (see module docstring)."""
+    xy = traj[:, 1:3]
+    ts = traj[:, 0]
+    prod = _producer(obstacles, sensing_range)
+    n = len(xy)
+    if n == 0:
+        return 0.0
+    total = 0.0
+    for i in range(n):
+        j = i
+        while j < n - 1 and np.linalg.norm(xy[j] - xy[i]) < lookahead:
+            j += 1
+        bev = prod.render(xy[i], ts[i])
+        total += float(bev.sample(RiskChannel.EPISTEMIC, xy[j:j + 1],
+                                  unobserved_value=1.0)[0])
+    return total / n

--- a/eval/mppi_sandbox/tests/test_blind_corner.py
+++ b/eval/mppi_sandbox/tests/test_blind_corner.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Blind-corner occlusion scenario + metric contract (Q-017 measurement).
+
+Q-017 found the epistemic shadow cost closed-loop *redundant* for a single
+convex obstacle (shadow ⊆ obstacle-cost). The missing piece it named was a
+scenario "where the shadow hides a low-obstacle-cost shortcut" — a genuine
+blind corner. This suite ships that scenario (`cafe_blind_corner_v0.yaml`)
+plus the occlusion metric pair (`eval.mppi_sandbox.occlusion`) that scores
+it, and pins down three properties:
+
+1. the scenario has a *real* blind spot (the declared pocket is occluded on
+   approach), so it is a valid epistemic test-bed — not another geometry
+   where σ is trivially inert;
+2. the oracle baseline rounds the corner and meets acceptance (the scenario
+   is solvable, so any epistemic behaviour change is a *choice*, not forced);
+3. the sightline-reveal metric is delayed (pocket revealed only after the
+   corner) — the non-zero, path-dependent scalar the EPISTEMIC channel can
+   be scored on, the way clearance scores the DYNAMIC channel.
+
+The forward-looking shadow-cost assertion (does `w_epist` reveal the pocket
+earlier / not raise exposure?) self-activates once `w_epist` lands on main
+via PR #67 — until then it skips, so this file is green on main today.
+"""
+
+import inspect
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from eval.mppi_sandbox.controllers import RiskMPPI, make_controller
+from eval.mppi_sandbox.obstacles import min_clearance
+from eval.mppi_sandbox.occlusion import (occlusion_exposure, point_sigma,
+                                         sightline_reveal)
+from eval.mppi_sandbox.run import ROBOT_RADIUS, run_scenario, simulate
+from eval.mppi_sandbox.scenario import load_scenario
+
+SCENARIO = "eval/scenarios/cafe_blind_corner_v0.yaml"
+
+
+def _pocket():
+    raw = yaml.safe_load(Path(SCENARIO).read_text())
+    p = raw["blind_pocket"]
+    return np.array([p["x"], p["y"]], dtype=float)
+
+
+class TestScenarioValidity:
+    def test_pocket_is_occluded_on_approach(self):
+        """The declared blind pocket must be genuinely unseen (σ=1) from the
+        start and from the mid-approach — otherwise the scenario is not a
+        blind corner and σ would be trivially inert (the Q-017 trap)."""
+        scen = load_scenario(SCENARIO)
+        pocket = _pocket()
+        assert point_sigma(scen.obstacles, scen.start[:2], 0.0, pocket) == 1.0
+        assert point_sigma(scen.obstacles, [2.0, 0.4], 0.0, pocket) == 1.0
+
+    def test_pocket_becomes_visible_after_rounding(self):
+        """Sanity on the other side: once the robot is past the wall top the
+        pocket is in sight — the scenario reveals, it does not permanently
+        hide (which would make the reveal metric degenerate)."""
+        scen = load_scenario(SCENARIO)
+        assert point_sigma(scen.obstacles, [3.2, -0.2], 0.0, _pocket()) < 0.5
+
+
+class TestBaselineSolvable:
+    def test_stock_rounds_corner_within_acceptance(self):
+        res = run_scenario(SCENARIO, controller="stock_mppi", seed=0)
+        assert res["pass"] is True, res["acceptance"]
+        assert res["collision"] is False
+        assert res["min_obstacle_clearance"] > 0.0
+        assert res["metrics"]["goal_reached"] == 1
+
+
+class TestSightlineMetric:
+    def test_reveal_is_delayed_not_from_start(self):
+        """The headline EPISTEMIC scalar: the pocket is hidden at the start
+        and only revealed partway along the path — a real, path-dependent
+        'how blind was the approach' number (clearance's occlusion-aware
+        analogue)."""
+        scen = load_scenario(SCENARIO)
+        traj = simulate(scen, make_controller("stock_mppi", scen, seed=0,
+                                              robot_radius=ROBOT_RADIUS))
+        rev = sightline_reveal(traj, scen.obstacles, _pocket())
+        assert rev["visible_from_start"] is False
+        assert rev["reveal_index"] is not None, "pocket never revealed"
+        assert 0.0 < rev["reveal_fraction"] < 1.0
+        assert rev["reveal_distance"] > 0.0
+
+    def test_exposure_metric_is_non_negative_and_finite(self):
+        scen = load_scenario(SCENARIO)
+        traj = simulate(scen, make_controller("stock_mppi", scen, seed=0,
+                                              robot_radius=ROBOT_RADIUS))
+        exp = occlusion_exposure(traj, scen.obstacles)
+        assert exp >= 0.0 and np.isfinite(exp)
+
+
+def _risk_mppi_has_wepist() -> bool:
+    return "w_epist" in inspect.signature(RiskMPPI.__init__).parameters
+
+
+class TestShadowCostForwardContract:
+    """Self-activating once PR #67 (ShadowCostCritic / w_epist) lands on main.
+
+    Conservative on purpose: the shadow cost is add-only (σ≥0, w_epist≥0), so
+    the strongest thing provable without over-claiming a future gain is that
+    turning it on must NOT break the solve nor drive the robot *blinder*
+    (later reveal / higher exposure). A later cycle can tighten this to a
+    strict reveal-earlier assertion once the gain is actually measured — the
+    honest Q-017 posture (no premature GREEN)."""
+
+    def test_shadow_cost_does_not_regress_blindness(self):
+        import pytest
+        if not _risk_mppi_has_wepist():
+            pytest.skip("w_epist not on main yet (PR #67) — forward contract")
+        scen = load_scenario(SCENARIO)
+        pocket = _pocket()
+        base = simulate(scen, make_controller("risk_mppi", scen, seed=0,
+                        robot_radius=ROBOT_RADIUS, w_risk=0.0,
+                        k_margin_per_sigma=0.0, w_epist=0.0))
+        shad = simulate(scen, make_controller("risk_mppi", scen, seed=0,
+                        robot_radius=ROBOT_RADIUS, w_risk=0.0,
+                        k_margin_per_sigma=0.0, w_epist=150.0))
+        # still solves
+        assert min_clearance(shad, scen.obstacles, ROBOT_RADIUS) > 0.0
+        # not blinder: reveal no later, exposure no higher (add-only floor)
+        rb = sightline_reveal(base, scen.obstacles, pocket)
+        rs = sightline_reveal(shad, scen.obstacles, pocket)
+        if rb["reveal_fraction"] is not None and rs["reveal_fraction"] is not None:
+            assert rs["reveal_fraction"] <= rb["reveal_fraction"] + 1e-6
+        assert (occlusion_exposure(shad, scen.obstacles)
+                <= occlusion_exposure(base, scen.obstacles) + 1e-6)

--- a/eval/scenarios/cafe_blind_corner_v0.yaml
+++ b/eval/scenarios/cafe_blind_corner_v0.yaml
@@ -1,0 +1,92 @@
+# cafe-blind-corner-v0: the geometry Q-017 asked for — a blind corner with a
+# genuinely occluded pocket the robot must round into, so an epistemic-σ
+# consumer (ShadowCostCritic w_epist, RiskInflationCritic k·σ) finally has a
+# spatial signal that obstacle-avoidance alone does not carry.
+#
+# Layout (world frame, meters):
+#
+#     y
+#     ^   .  (2.5,0.6) apex — robot rounds the wall's TOP end here
+#   0 +----########------------------> x
+#  -1 |       ########  wall @ x=2.5   . goal (4.5,-0.6)
+#  -2 |       ########                 . blind_pocket (3.0,-0.4)  <-- occluded
+#          0   2.5    3       4    5       during the whole approach
+#
+# A vertical wall of overlapping r=0.3 discs sits at x=2.5, spanning
+# y∈[-2.2, 0.2] (top surface ~y=0.5). The robot starts at the origin heading
+# +X, arcs up over the wall's top end (apex ~y=0.6 near x=2.5), then descends
+# behind the wall to a goal at (4.5, -0.6). The pocket at (3.0, -0.4) — the
+# low-y space *behind* the wall the descent passes near — is occluded (σ=1)
+# for the entire approach: it only enters line-of-sight after the robot has
+# rounded the top corner (measured this cycle: first visible at ~2.8 m of the
+# 5.3 m path, robot 1.4 m away).
+#
+# Baseline MPPI has oracle obstacle knowledge, so it already clears the wall
+# geometrically. The point of this scenario is NOT clearance (the oracle
+# baseline clears it) but *occlusion* — the '가려진 obstacle' (occluded)
+# north-star class. The metric of interest is the sightline-reveal / exposure
+# pair in eval/mppi_sandbox/occlusion.py, exercised by tests/test_blind_corner.py.
+
+name: cafe-blind-corner-v0
+description: Round an occluding wall's top corner into a blind pocket behind it.
+env_class: A  # indoor-narrow
+
+launch:
+  file: jackal_cafe.launch.py
+  args:
+    headless: 'false'
+    use_rviz: 'true'
+
+world: cafe3_jazzy.sdf.xacro
+
+start: { x: 0.0, y: 0.0,  yaw: 0.0 }
+goal:  { x: 4.5, y: -0.6, yaw: 0.0 }
+
+# The pocket the wall keeps hidden until the robot rounds the top corner.
+# Read by tests/test_blind_corner.py to assert the scenario has a real blind
+# spot (load_scenario ignores this key; it is documentation + test contract).
+blind_pocket: { x: 3.0, y: -0.4 }
+
+reference_path:
+  type: arc
+  waypoints:
+    - [0.0,  0.0,  0.0]
+    - [1.5,  0.3,  0.4]
+    - [2.5,  0.6,  0.0]
+    - [3.3,  0.1, -0.6]
+    - [4.0, -0.6, -0.4]
+    - [4.5, -0.6,  0.0]
+
+target_speed_mps: 0.4
+expected_duration_s: 18
+
+# Wall of overlapping r=0.3 discs at x=2.5. Declared under dynamic_obstacles:
+# only because load_scenario ingests obstacles from that block; they are
+# static (no waypoints) → GTBevProducer treats them as STATIC-channel
+# occluders and stock_mppi tracks them with oracle knowledge. Sandbox-only
+# occluder set — the Gazebo backend ignores this and uses the world SDF.
+dynamic_obstacles:
+  - { id: wall_0, init: { x: 2.5, y:  0.2 }, radius: 0.3 }
+  - { id: wall_1, init: { x: 2.5, y: -0.3 }, radius: 0.3 }
+  - { id: wall_2, init: { x: 2.5, y: -0.8 }, radius: 0.3 }
+  - { id: wall_3, init: { x: 2.5, y: -1.3 }, radius: 0.3 }
+  - { id: wall_4, init: { x: 2.5, y: -1.8 }, radius: 0.3 }
+
+acceptance:
+  cte_rms_max: 0.4
+  cte_max: 0.8
+  completion_min: 0.99
+  goal_xy_tol: 0.2
+  goal_yaw_tol: 0.5
+  min_distance_to_obstacle: 0.0   # must not hit the wall
+  collision: 0
+
+notes: |
+  - v0: single wall, single approach, static occluder. Follow-ups (v1):
+    (a) a genuine L-corner (two perpendicular walls); (b) a *scripted*
+    obstacle that emerges from the blind pocket once the robot commits, to
+    couple the DYNAMIC risk channel with EPISTEMIC caution; (c) a
+    visibility-gated obstacle cost so the baseline is genuinely blind to the
+    pocket (right now stock_mppi has oracle knowledge, so epistemic caution
+    only changes *how blind* the approach is, not whether a hidden obstacle
+    is avoided — see docs/deliberations.md Q-017).

--- a/journal/2026-07/13-02-p3-blind-corner-occlusion-scenario.md
+++ b/journal/2026-07/13-02-p3-blind-corner-occlusion-scenario.md
@@ -1,0 +1,61 @@
+# P3 blind-corner occlusion scenario + sightline metric (Q-017 test-bed)
+
+- **Cycle**: 2026-07-13 02:00 KST
+- **Branch**: `autoresearch/p3-blind-corner-occlusion-scenario`
+- **TODO**: `p3-blind-corner` Blind-corner occlusion scenario (STATE next-actionable #1)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- Built `eval/scenarios/cafe_blind_corner_v0.yaml`: a wall of r=0.3 discs at
+  x=2.5 the robot rounds at the top, descending to a goal *behind* it, with a
+  declared `blind_pocket (3.0,-0.4)` that stays occluded during the approach.
+- Added `eval/mppi_sandbox/occlusion.py` — `sightline_reveal` (arclength /
+  distance a hidden point first comes into view) + `occlusion_exposure`
+  (mean σ of the pose the robot is about to enter). EPISTEMIC-channel scalars.
+- Added `tests/test_blind_corner.py` (5 tests + 1 self-activating forward
+  contract for `w_epist`). Empirically iterated the geometry before asserting.
+
+## What worked / what failed
+- Scenario is valid + solvable: pocket σ=1 the whole approach, baseline
+  `stock_mppi` passes acceptance (cte_rms 0.175, clearance +0.145, no hit).
+- Sightline-reveal is real and non-trivial: pocket first visible at **2.8 m of
+  the 5.3 m path**, robot 1.4 m away — a path-dependent "how blind" number.
+- **Executed-path occlusion exposure is ~0** for the smooth oracle MPPI. First
+  geometries (wall-top arc, narrow gaps) either gave 0 exposure or sealed the
+  corridor (timeout). The 0 is not a bug: a smooth path curves *around* the
+  occluder, so its forward lookahead never enters the side-lying shadow.
+
+## North-star delta
+- + First occlusion test-bed + EPISTEMIC-channel metric in the sandbox — the
+  '가려진 obstacle' class now has a scenario and a scalar to score, where
+  before it had neither (the exact STATE bottleneck).
+- No closed-loop north-star metric *moved* yet — this builds the surface on
+  which the epistemic critics will be scored, not a controller win.
+
+## Key learnings
+- The additive shadow cost's inertness is deeper than Q-017's single-obstacle
+  case: for *any* smooth path, occluded cells sit off the forward trajectory,
+  so charging executed rollout points for σ has little to bite on. The real
+  unblock is a **visibility-gated obstacle cost** — make `stock_mppi` blind to
+  unobserved obstacles so epistemic caution changes collision outcomes, not
+  just approach blindness. That, plus a scripted obstacle emerging from the
+  pocket, is the scenario where σ finally moves clearance/near-miss.
+- Sightline-reveal (not executed-path exposure) is the metric to score
+  epistemic controllers on: it is non-zero, path-dependent, and rewards
+  seeing sooner.
+
+## Recommended next 1–3 priorities
+1. **Visibility-gated obstacle cost** in a sandbox controller variant (avoid
+   only *observed* obstacles) → the blind pocket becomes a genuine hazard the
+   oracle baseline hits and an epistemic-aware controller avoids. Unblocks a
+   real Q-017 resolution with a clearance/near-miss delta.
+2. **Blind-corner v1**: scripted obstacle emerging from the pocket once the
+   robot commits — couples DYNAMIC risk with EPISTEMIC caution.
+3. Once PR #67 (w_epist) lands, run the self-activating forward contract and
+   measure sightline-reveal under `w_epist>0`.
+
+## Artifacts
+- PR: #68 (autoresearch/p3-blind-corner-occlusion-scenario)
+- Files touched: eval/scenarios/cafe_blind_corner_v0.yaml, eval/mppi_sandbox/occlusion.py, eval/mppi_sandbox/tests/test_blind_corner.py, results/p3-blind-corner-occlusion-scenario.tsv
+- TSV row appended: yes

--- a/results/p3-blind-corner-occlusion-scenario.tsv
+++ b/results/p3-blind-corner-occlusion-scenario.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-13T02:12:11+09:00	pending	sandbox:blind_corner=5/5	keep	blind-corner scenario+occlusion metric; baseline pass, pocket occluded on approach, sightline-reveal @2.8m/5.3m; exposure~0 (smooth-path, sharpens Q-017)


### PR DESCRIPTION
## Summary
- **New scenario** `eval/scenarios/cafe_blind_corner_v0.yaml` — a blind corner with a genuinely occluded pocket the robot rounds a wall into. This is the geometry Q-017 asked for ("shadow hides a low-obstacle-cost shortcut"), the missing test-bed for the EPISTEMIC channel.
- **New metric module** `eval/mppi_sandbox/occlusion.py` — `sightline_reveal` (at what arclength/distance does a hidden pocket first come into view?) and `occlusion_exposure` (mean σ of the pose the robot is about to enter). The EPISTEMIC-channel scalar analogue to `min_obstacle_clearance` for the DYNAMIC channel.
- **New tests** `eval/mppi_sandbox/tests/test_blind_corner.py` — scenario validity (pocket occluded on approach), baseline solvable within acceptance, sightline-reveal delayed, and a **self-activating forward contract** for `w_epist` (skips on main until PR #67 lands).

## Findings (measured this cycle)
- Baseline `stock_mppi` passes acceptance (cte_rms 0.175, no collision, clearance +0.145).
- The pocket `(3.0,-0.4)` is occluded (σ=1) for the entire approach; first revealed at **~2.8 m of the 5.3 m path**, robot 1.4 m away — a real, path-dependent "how blind was the approach" number.
- **Executed-path occlusion exposure is ~0 for a smooth oracle-baseline MPPI** — the occluded region sits off to the side of the forward path, not on it. This *generalises* the Q-017 redundancy finding: the additive shadow cost needs either a visibility-gated obstacle cost (so the baseline is genuinely blind) or a rollout-fan/sightline metric, not the executed path. Recorded, not papered over.

## Test plan
- [x] `pytest eval/mppi_sandbox/tests/test_blind_corner.py` → 5 passed, 1 skipped (forward contract dormant until #67).
- [x] New files are purely additive (scenario + metric + test); no existing module touched.
- [ ] ⚠️ **Pre-existing red, not from this PR**: `test_risk_mppi.py::...test_epistemic_margin_widens_berth_in_occlusion_geometry` fails on `main` today and is fixed by open PRs #66 / #67. sandbox-ci will show it until those land; this branch does not touch that test or `risk_mppi.py`.

## Closes
- TODO `p3-blind-corner`: Blind-corner occlusion scenario where σ can move the needle (STATE next-actionable #1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)