### PR TITLE
[auto] P3 visibility-gated obstacle cost (vg_mppi): occlusion moves a collision outcome

### DIFF
--- a/eval/mppi_sandbox/controllers/__init__.py
+++ b/eval/mppi_sandbox/controllers/__init__.py
@@ -15,11 +15,13 @@ from __future__ import annotations
 from .cbf_mppi import CBFMPPI
 from .risk_mppi import RiskMPPI
 from .stock_mppi import StockMPPI
+from .visibility_gated_mppi import VisibilityGatedMPPI
 
 REGISTRY = {
     "stock_mppi": StockMPPI,
     "risk_mppi": RiskMPPI,
     "cbf_mppi": CBFMPPI,
+    "vg_mppi": VisibilityGatedMPPI,
 }
 
 

--- a/eval/mppi_sandbox/controllers/visibility_gated_mppi.py
+++ b/eval/mppi_sandbox/controllers/visibility_gated_mppi.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Visibility-gated MPPI — StockMPPI that charges only *observed* obstacles.
+
+The sandbox baseline (`stock_mppi`) plans against oracle obstacle knowledge:
+its soft barrier + hard collision penalty sum over *every* obstacle at its
+ground-truth position, regardless of whether the robot could actually see it.
+Under that model occlusion can never change a collision outcome — it only
+changes how blind the approach *looks* (STATE bottleneck, 2026-07-13).
+
+This variant closes that gap on the *cost* side. At each control step it
+filters the obstacle set to those the robot currently observes — nearest
+surface within `sensing_range` AND not hidden in the line-of-sight shadow of a
+*nearer* obstacle disc — and lets the inherited StockMPPI cost act on that
+subset only. The visibility geometry mirrors ``GTBevProducer._occlusion``
+(D-012), so the representation-side observability mask and this
+controller-side gate agree by construction.
+
+Consequence (the Q-017 unblock this enables): an obstacle occluded behind a
+nearer one is invisible to the planner, so a visibility-gated robot drives
+toward a hidden pocket the oracle baseline routes around — occlusion finally
+moves a clearance/collision outcome, and an epistemic-aware controller has a
+real failure to beat.
+
+Ablation invariant: with ``sensing_range = inf`` (default) and no obstacle
+occluding another, every obstacle is observed, so the gate is a no-op and the
+run reproduces ``stock_mppi`` byte-for-byte. Inter-obstacle occlusion still
+fires at infinite range (a nearer disc hides a farther one on the same ray) —
+that is the intended lever, so the invariant holds only when no such shadow
+exists.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..dynamics import Limits
+from .stock_mppi import MPPIParams, StockMPPI
+
+
+class VisibilityGatedMPPI(StockMPPI):
+    def __init__(self, scenario, seed: int = 0,
+                 params: MPPIParams | None = None,
+                 limits: Limits | None = None,
+                 robot_radius: float = 0.3,
+                 sensing_range: float = float("inf")):
+        super().__init__(scenario, seed=seed, params=params, limits=limits,
+                         robot_radius=robot_radius)
+        # StockMPPI.__init__ bound self.obstacles = scenario.obstacles; keep the
+        # ground-truth set separately and expose the per-step visible subset.
+        self._all_obstacles = list(self.obstacles)
+        self.sensing_range = sensing_range
+        self.last_observed = list(self.obstacles)   # introspection for tests
+
+    def command(self, state: np.ndarray, t: float) -> np.ndarray:
+        self.last_observed = self.observed_obstacles(state[:2], t)
+        self.obstacles = self.last_observed          # inherited _cost reads this
+        return super().command(state, t)
+
+    def observed_obstacles(self, robot_xy: np.ndarray, t: float) -> list:
+        """Obstacles visible from ``robot_xy`` at time ``t``.
+
+        Visible = nearest surface within ``sensing_range`` AND the robot→center
+        ray is not blocked by a *nearer* obstacle disc. A disc never occludes
+        itself.
+        """
+        robot_xy = np.asarray(robot_xy, dtype=float)
+        centers = [ob.position(t) for ob in self._all_obstacles]
+        dists = [float(np.linalg.norm(c - robot_xy)) for c in centers]
+        observed = []
+        for i, ob in enumerate(self._all_obstacles):
+            if dists[i] - ob.radius > self.sensing_range:
+                continue
+            if self._occluded(robot_xy, centers[i], dists[i], i, centers, dists):
+                continue
+            observed.append(ob)
+        return observed
+
+    def _occluded(self, robot_xy, target_c, target_d, target_i,
+                  centers, dists) -> bool:
+        """True if a nearer obstacle disc crosses the robot→target sightline."""
+        seg = target_c - robot_xy
+        seg_len2 = max(float(seg @ seg), 1e-12)
+        for j, oc in enumerate(self._all_obstacles):
+            if j == target_i or dists[j] >= target_d:
+                continue                              # only strictly nearer discs
+            u = np.clip(float((centers[j] - robot_xy) @ seg) / seg_len2, 0.0, 1.0)
+            foot = robot_xy + u * seg
+            if float(np.linalg.norm(foot - centers[j])) <= oc.radius:
+                return True
+        return False

--- a/eval/mppi_sandbox/tests/test_visibility_gated_mppi.py
+++ b/eval/mppi_sandbox/tests/test_visibility_gated_mppi.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""visibility_gated_mppi (vg_mppi) contract + north-star tests.
+
+Four claim classes:
+
+1. Line-of-sight occlusion gate — a disc hidden behind a nearer disc is not in
+   the observed set; it reveals once the robot moves off the shadowing ray.
+2. Sensing-range gate — a disc whose nearest surface is beyond sensing_range is
+   not observed; within range it is.
+3. Ablation invariance — with sensing_range=inf and no obstacle occluding
+   another, vg_mppi reproduces stock_mppi byte-for-byte (so any behaviour delta
+   is attributable to the gate, not the plumbing).
+4. North-star effect — on cafe_blind_approach_v0, the oracle (stock_mppi) never
+   collides while the gated controller collides on a fraction of seeds and keeps
+   a strictly smaller mean clearance: occlusion finally *moves a collision
+   outcome*, the STATE 2026-07-13 bottleneck.
+"""
+
+import numpy as np
+
+from eval.mppi_sandbox.controllers import make_controller
+from eval.mppi_sandbox.controllers.visibility_gated_mppi import VisibilityGatedMPPI
+from eval.mppi_sandbox.obstacles import CircleObstacle, min_clearance
+from eval.mppi_sandbox.run import ROBOT_RADIUS, run_scenario, simulate
+from eval.mppi_sandbox.scenario import load_scenario
+from eval.mppi_sandbox.tests.test_sandbox import _straight_scenario
+
+BLIND_YAML = "eval/scenarios/cafe_blind_approach_v0.yaml"
+
+
+class TestLineOfSightGate:
+    def test_hazard_behind_nearer_disc_is_occluded_then_revealed(self):
+        # near occluder on the x=0 line, hazard directly behind it
+        occ = CircleObstacle(0.0, -2.5, radius=0.3)
+        haz = CircleObstacle(0.0, -4.3, radius=0.3)
+        scen = _straight_scenario(obstacles=[occ, haz])
+        vg = make_controller("vg_mppi", scen, seed=0, robot_radius=ROBOT_RADIUS)
+
+        # from the start pose the hazard sits in the occluder's shadow
+        seen_start = vg.observed_obstacles(np.array([0.0, 0.0]), 0.0)
+        assert occ in seen_start and haz not in seen_start
+
+        # step off the shadowing ray → hazard reveals (occluder still seen)
+        seen_side = vg.observed_obstacles(np.array([0.8, -3.0]), 0.0)
+        assert haz in seen_side
+
+    def test_disc_never_occludes_itself(self):
+        ob = CircleObstacle(0.0, -3.0, radius=0.5)
+        scen = _straight_scenario(obstacles=[ob])
+        vg = make_controller("vg_mppi", scen, seed=0, robot_radius=ROBOT_RADIUS)
+        assert vg.observed_obstacles(np.array([0.0, 0.0]), 0.0) == [ob]
+
+
+class TestSensingRangeGate:
+    def test_beyond_range_unobserved_within_range_observed(self):
+        ob = CircleObstacle(0.0, -4.0, radius=0.4)   # nearest surface at 3.6 m
+        scen = _straight_scenario(obstacles=[ob])
+        vg = make_controller("vg_mppi", scen, seed=0, robot_radius=ROBOT_RADIUS,
+                             sensing_range=1.0)
+        assert vg.observed_obstacles(np.array([0.0, 0.0]), 0.0) == []      # 3.6 > 1.0
+        assert vg.observed_obstacles(np.array([0.0, -3.2]), 0.0) == [ob]   # 0.4 < 1.0
+
+
+class TestAblationInvariance:
+    def test_inf_range_single_obstacle_reproduces_stock_byte_for_byte(self):
+        ob = CircleObstacle(0.3, -2.0, radius=0.3)
+        scen = _straight_scenario(obstacles=[ob], expected_duration=12.0)
+        stock = make_controller("stock_mppi", scen, seed=5)
+        vg = make_controller("vg_mppi", scen, seed=5)   # sensing_range=inf default
+        np.testing.assert_array_equal(simulate(scen, stock), simulate(scen, vg))
+
+    def test_default_sensing_range_is_infinite(self):
+        scen = _straight_scenario(obstacles=[CircleObstacle(0.0, -2.0)])
+        vg = make_controller("vg_mppi", scen, seed=0)
+        assert vg.sensing_range == float("inf")
+        assert isinstance(vg, VisibilityGatedMPPI)
+
+
+class TestOcclusionMovesCollisionOutcome:
+    """The Q-017 unblock: a visibility-gated baseline hits a hazard the oracle
+    routes around. Aggregate over seeds — the effect is a raised collision
+    *rate*, not a single deterministic crash (MPPI is stochastic per seed)."""
+
+    def test_gated_collides_where_oracle_never_does(self):
+        scen = load_scenario(BLIND_YAML)
+        haz = scen.obstacles[0]
+        seeds = range(8)
+        stock_clr = [
+            min_clearance(
+                simulate(scen, make_controller("stock_mppi", scen, seed=s,
+                                                robot_radius=ROBOT_RADIUS)),
+                [haz], ROBOT_RADIUS)
+            for s in seeds
+        ]
+        vg_clr = [
+            min_clearance(
+                simulate(scen, make_controller("vg_mppi", scen, seed=s,
+                                                robot_radius=ROBOT_RADIUS,
+                                                sensing_range=1.0)),
+                [haz], ROBOT_RADIUS)
+            for s in seeds
+        ]
+        # oracle sees the hazard from the start → never collides
+        assert all(c >= 0.0 for c in stock_clr), stock_clr
+        # blind controller collides on ≥1 seed and is worse in the mean
+        assert sum(c < 0.0 for c in vg_clr) >= 1, vg_clr
+        assert np.mean(vg_clr) < np.mean(stock_clr)
+
+    def test_run_scenario_reports_gated_collision(self):
+        # seed 4 deterministically collides for the gated controller and clears
+        # for the oracle — exercises the run_scenario JSON/acceptance path.
+        oracle = run_scenario(BLIND_YAML, controller="stock_mppi", seed=4)
+        blind = run_scenario(BLIND_YAML, controller="vg_mppi", seed=4,
+                             sensing_range=1.0)
+        assert oracle["collision"] is False
+        assert blind["collision"] is True
+        # acceptance encodes the finding: oracle passes, blind fails on clearance
+        assert oracle["acceptance"]["min_distance_to_obstacle"] is True
+        assert blind["acceptance"]["min_distance_to_obstacle"] is False

--- a/eval/mppi_sandbox/tests/test_visibility_gated_mppi.py
+++ b/eval/mppi_sandbox/tests/test_visibility_gated_mppi.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """visibility_gated_mppi (vg_mppi) contract + north-star tests.
 
-Four claim classes:
+Five claim classes:
 
 1. Line-of-sight occlusion gate — a disc hidden behind a nearer disc is not in
    the observed set; it reveals once the robot moves off the shadowing ray.
@@ -14,18 +14,72 @@ Four claim classes:
    collides while the gated controller collides on a fraction of seeds and keeps
    a strictly smaller mean clearance: occlusion finally *moves a collision
    outcome*, the STATE 2026-07-13 bottleneck.
+5. Speed-controlled effect — class 4 with the gated arm handicapped below the
+   oracle's realized speed, so the separation cannot be read as "the blind arm
+   just drove faster".
+
+Regime caveat — read before quoting any number here (measured 2026-08-02, N=24):
+
+  As shipped (no speed handicap) the two metrics separate in *disjoint*
+  regimes, so neither alone is a safe headline:
+
+    metric                    shipped tuning        speed-controlled (v_max .30)
+    collisions stock vs vg    0/24 vs 6/24          0/24 vs 14/24
+                              Fisher p = 0.011      p < 1e-4
+    paired min_clearance      15/24 stock-favoured  24/24 stock-favoured
+                              sign p = 0.15 (n.s.)  p < 1e-4
+
+  Two consequences the class-4 test cannot state on its own:
+
+  (a) The collision separation is *regime-specific to this scene's tuning*.
+      Re-scoping the scene to give the oracle real headroom (lowering w_path,
+      or moving the hazard offset with the planner bit-identical) drives it to
+      0/24 vs 0/24, p = 1.00 — while the clearance separation strengthens to
+      23-24/24. So class 4's collision assertion is a true lower bound *here*
+      and must not be generalized to "occlusion raises collision rate".
+  (b) Unhandicapped, the gated arm runs 1.58x the oracle's speed (0.439 vs
+      0.279 m/s) — a live confound. Removing it does not weaken the effect, it
+      *strengthens* it in both metrics (class 5): handicapped to 0.73x the
+      oracle's speed the gated arm collides 20/24. The blind arm's
+      disadvantage is therefore not that it drives fast.
+
+  Every comparison below asserts a completion guard (both arms inside
+  goal_xy_tol) — without it "0 collisions" is purchasable by not moving.
 """
 
 import numpy as np
 
 from eval.mppi_sandbox.controllers import make_controller
 from eval.mppi_sandbox.controllers.visibility_gated_mppi import VisibilityGatedMPPI
+from eval.mppi_sandbox.dynamics import Limits
 from eval.mppi_sandbox.obstacles import CircleObstacle, min_clearance
 from eval.mppi_sandbox.run import ROBOT_RADIUS, run_scenario, simulate
 from eval.mppi_sandbox.scenario import load_scenario
 from eval.mppi_sandbox.tests.test_sandbox import _straight_scenario
 
 BLIND_YAML = "eval/scenarios/cafe_blind_approach_v0.yaml"
+
+
+def _reached_goal(traj: np.ndarray, scen) -> bool:
+    """Completion guard: did this arm actually finish the path?
+
+    A safety comparison whose arms are not both at the goal is not a safety
+    comparison — 0 collisions and a wide berth are both purchasable by giving
+    up early (a 2026-08-02 sweep produced a +1.53 m 'berth' at p = 1.19e-07
+    that was entirely freeze, oracle d_goal 5.42 m on a 7 m path). Assert this
+    on every arm of every comparison, on the same run that scores safety.
+    """
+    tol = float(scen.acceptance.get("goal_xy_tol", 0.2))
+    return bool(np.linalg.norm(traj[-1, 1:3] - scen.goal[:2]) <= tol)
+
+
+def _run(scen, kind, seed, *, v_max=None, **kw):
+    """Simulate one arm; return (trajectory, min_clearance, reached_goal)."""
+    ctrl = make_controller(kind, scen, seed=seed, robot_radius=ROBOT_RADIUS, **kw)
+    traj = simulate(scen, ctrl, limits=Limits(v_max=v_max) if v_max else None)
+    return (traj,
+            min_clearance(traj, [scen.obstacles[0]], ROBOT_RADIUS),
+            _reached_goal(traj, scen))
 
 
 class TestLineOfSightGate:
@@ -83,26 +137,23 @@ class TestOcclusionMovesCollisionOutcome:
 
     def test_gated_collides_where_oracle_never_does(self):
         scen = load_scenario(BLIND_YAML)
-        haz = scen.obstacles[0]
         seeds = range(8)
-        stock_clr = [
-            min_clearance(
-                simulate(scen, make_controller("stock_mppi", scen, seed=s,
-                                                robot_radius=ROBOT_RADIUS)),
-                [haz], ROBOT_RADIUS)
-            for s in seeds
-        ]
-        vg_clr = [
-            min_clearance(
-                simulate(scen, make_controller("vg_mppi", scen, seed=s,
-                                                robot_radius=ROBOT_RADIUS,
-                                                sensing_range=1.0)),
-                [haz], ROBOT_RADIUS)
-            for s in seeds
-        ]
+        stock = [_run(scen, "stock_mppi", s) for s in seeds]
+        vg = [_run(scen, "vg_mppi", s, sensing_range=1.0) for s in seeds]
+
+        # completion guard first — neither arm may buy its score by stopping
+        assert all(r for _, _, r in stock), "oracle did not reach the goal"
+        assert all(r for _, _, r in vg), "gated arm did not reach the goal"
+
+        stock_clr = [c for _, c, _ in stock]
+        vg_clr = [c for _, c, _ in vg]
         # oracle sees the hazard from the start → never collides
         assert all(c >= 0.0 for c in stock_clr), stock_clr
-        # blind controller collides on ≥1 seed and is worse in the mean
+        # blind controller collides on ≥1 seed and is worse in the mean.
+        # NOTE: a lower bound in *this* tuning only — see the regime caveat in
+        # the module docstring. The mean gap here is tail-driven (the paired
+        # comparison is only 15/24 at N=24, sign p = 0.15); the distributional
+        # claim needs the speed control below.
         assert sum(c < 0.0 for c in vg_clr) >= 1, vg_clr
         assert np.mean(vg_clr) < np.mean(stock_clr)
 
@@ -117,3 +168,40 @@ class TestOcclusionMovesCollisionOutcome:
         # acceptance encodes the finding: oracle passes, blind fails on clearance
         assert oracle["acceptance"]["min_distance_to_obstacle"] is True
         assert blind["acceptance"]["min_distance_to_obstacle"] is False
+
+
+class TestEffectSurvivesSpeedControl:
+    """Class 5 — the confound removal class 4 cannot do on its own.
+
+    Unhandicapped, the gated arm runs 1.58x the oracle's realized speed, so
+    "it collides more" is confounded with "it drives faster". Handicapping it
+    to ~0.83x removes the confound in the direction that could only *hurt* the
+    finding — and the separation gets stronger in both metrics, which is the
+    point: the gated arm's deficit is representational, not kinematic.
+    """
+
+    VG_V_MAX = 0.30      # oracle realizes ~0.279 m/s unhandicapped
+
+    def test_slower_gated_arm_still_collides_and_keeps_less_clearance(self):
+        scen = load_scenario(BLIND_YAML)
+        seeds = range(8)
+        stock = [_run(scen, "stock_mppi", s) for s in seeds]
+        vg = [_run(scen, "vg_mppi", s, v_max=self.VG_V_MAX, sensing_range=1.0)
+              for s in seeds]
+
+        assert all(r for _, _, r in stock), "oracle did not reach the goal"
+        assert all(r for _, _, r in vg), "handicapped gated arm did not finish"
+
+        # the handicap actually bound: gated arm is no faster than the oracle
+        mean_v = lambda arms: float(np.mean([np.abs(t[:, 4]).mean()
+                                             for t, _, _ in arms]))
+        assert mean_v(vg) < mean_v(stock), (mean_v(vg), mean_v(stock))
+
+        stock_clr = [c for _, c, _ in stock]
+        vg_clr = [c for _, c, _ in vg]
+        assert all(c >= 0.0 for c in stock_clr), stock_clr
+        assert sum(c < 0.0 for c in vg_clr) >= 1, vg_clr
+        # paired, not mean: every seed favours the oracle once speed is held
+        # down (8/8 here; 24/24 at N=24, vs 15/24 unhandicapped)
+        assert all(s > v for s, v in zip(stock_clr, vg_clr)), list(
+            zip(stock_clr, vg_clr))

--- a/eval/scenarios/cafe_blind_approach_v0.yaml
+++ b/eval/scenarios/cafe_blind_approach_v0.yaml
@@ -1,0 +1,62 @@
+# cafe-blind-approach-v0: a hazard on the path that a limited-sensing robot
+# cannot perceive until it is dangerously close.
+#
+# Purpose (the STATE 2026-07-13 bottleneck test-bed, built independently of the
+# still-unmerged cafe_blind_corner_v0): give the sandbox a scene where a
+# *visibility-gated* controller (vg_mppi with a finite sensing_range) only sees
+# the hazard on late reveal, while the oracle baseline (stock_mppi) sees it from
+# the start. The robot approaches at 0.9 m/s, so a late reveal leaves little
+# room — the oracle routes around and clears; the blind controller collides on a
+# fraction of seeds. This is the smallest scene in which *occlusion moves a
+# collision outcome*, the exact gap the bottleneck names.
+#
+# The line-of-sight (behind-another-disc) half of the visibility model is
+# exercised as a unit test with inline obstacles; here the gate is driven by
+# sensing range, the range half of the same model.
+#
+# NOTE: sandbox-only scene (no Gazebo world). `launch:`/`world:` omitted;
+# scenario.py ignores them anyway (D-016).
+
+name: cafe-blind-approach-v0
+description: >
+  Single static disc at (0, -4.0) on a straight -Y path, approached at 0.9 m/s.
+  Oracle MPPI plans a clear berth; a visibility-gated MPPI with sensing_range≈1 m
+  only reveals it late and collides on a fraction of seeds.
+env_class: A  # indoor-narrow
+
+start: { x: 0.0,  y:  0.0, yaw: -1.5708 }
+goal:  { x: 0.0,  y: -7.0, yaw: -1.5708 }
+
+reference_path:
+  type: straight
+  waypoints:
+    - [0.0,  0.0, -1.5708]
+    - [0.0, -2.0, -1.5708]
+    - [0.0, -4.0, -1.5708]
+    - [0.0, -7.0, -1.5708]
+
+target_speed_mps: 0.9
+expected_duration_s: 9
+
+dynamic_obstacles:
+  - id: blind_hazard
+    init: { x: 0.0, y: -4.0 }
+    radius: 0.4
+
+acceptance:
+  completion_min: 0.99
+  goal_xy_tol: 0.25
+  goal_yaw_tol: 0.3
+  # Oracle stock_mppi clears (>0); the gated controller is expected to breach
+  # this on some seeds — that gap is the finding, asserted in pytest.
+  min_distance_to_obstacle: 0.0
+
+notes: |
+  - Static obstacle (no `waypoints:`) → position(t) constant, occlusion purely
+    geometric and deterministic per seed.
+  - Run the blind controller via:
+      python -m eval.mppi_sandbox.run eval/scenarios/cafe_blind_approach_v0.yaml \
+        --controller vg_mppi --ctrl-arg sensing_range=1.0 --seed 4
+    (seeds 4/5/7 collide; stock_mppi on the same scene clears on every seed).
+  - vg_mppi with the default sensing_range=inf reproduces stock_mppi exactly on
+    this single-obstacle scene (ablation invariant).

--- a/journal/2026-07/16-17-p3-visibility-gated-obstacle-cost.md
+++ b/journal/2026-07/16-17-p3-visibility-gated-obstacle-cost.md
@@ -1,0 +1,61 @@
+# Visibility-gated obstacle cost — occlusion finally moves a collision outcome
+
+- **Cycle**: 2026-07-16 17:00 KST
+- **Branch**: `autoresearch/p3-visibility-gated-obstacle-cost`
+- **TODO**: `vg-obscost` Visibility-gated obstacle cost (STATE Next-actionable #1)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+- Added `VisibilityGatedMPPI` (`vg_mppi`): a `StockMPPI` variant that, each control
+  step, filters the obstacle set to those the robot *observes* — nearest surface
+  within `sensing_range` AND not in the line-of-sight shadow of a nearer disc —
+  and lets the inherited cost act on that subset. Gate geometry mirrors
+  `GTBevProducer._occlusion` (D-012).
+- New on-main scenario `cafe_blind_approach_v0` (single hazard, straight 0.9 m/s
+  approach) — independent of the still-unmerged `cafe_blind_corner_v0` (#68), so no
+  branch-stacking.
+- 7 pytest cases: LoS occlusion gate, sensing-range gate, byte-for-byte ablation,
+  aggregate collision-rate, run_scenario JSON path.
+
+## What worked / what failed
+- **Worked**: occlusion now moves a *collision* outcome. `vg_mppi(sensing_range=1.0)`
+  collides on seeds 4/5/7 (clearance −0.23 m) while `stock_mppi` clears all 8 seeds.
+  The true Q-017 unblock the bottleneck asked for.
+- **Worked**: ablation invariant holds — `vg_mppi(inf)` on a single-obstacle scene
+  reproduces `stock_mppi` byte-for-byte, so behaviour deltas are attributable to the gate.
+- **Failed (informative)**: min-clearance alone does *not* separate oracle from gated on
+  late reveal — the agile diff-drive + `w_collision=1e4` barrier make both graze the
+  ~few-cm barrier floor once the hazard is seen. The separating signal is the raised
+  **collision rate**, not surviving clearance. A single disc can't reproduce a persistent
+  blind corner either: swerving to avoid the near occluder de-occludes the hazard early
+  (why I switched the closed-loop demo from inter-obstacle occlusion to a sensing-range gate).
+
+## North-star delta
+- **+ occlusion now changes a collision metric** (0/8 → 3/8) — the first sandbox scene
+  where a non-oracle observation model produces a measurable safety failure. This is the
+  baseline an epistemic-aware controller must beat.
+- + a reusable `vg_mppi` controller + `cafe_blind_approach_v0` scenario on main.
+
+## Key learnings
+- The right occlusion-cost metric on this plant is **collision rate over seeds**, not
+  min-clearance (which saturates at the barrier floor). P5's occlusion axis should score
+  collision/near-miss rate, not surviving clearance.
+- Pure inter-obstacle (single-disc) occlusion is self-defeating for closed-loop demos:
+  avoiding the occluder reveals the shadow. A persistent blind corner needs the L-wall
+  geometry of #68, or a range gate (used here) that doesn't depend on approach angle.
+
+## Recommended next 1–3 priorities
+1. **Epistemic-aware controller vs `vg_mppi` on `cafe_blind_approach_v0`** — does widening
+   berth into the unobserved region (RiskInflationCritic `k·σ`, or a beyond-range frontier
+   term) recover the oracle's 0/8 collision rate? This is the payoff experiment.
+2. **Once #66/#67/#68 land**: port `vg_mppi` onto `cafe_blind_corner_v0` (L-wall) to test
+   the persistent-occlusion geometry where the range gate isn't needed.
+3. **P5 occlusion metric**: adopt collision/near-miss *rate over seeds* as the occlusion-
+   sensitivity score (min-clearance saturates).
+
+## Artifacts
+- PR: #69 (autoresearch/p3-visibility-gated-obstacle-cost)
+- Files touched: eval/mppi_sandbox/controllers/visibility_gated_mppi.py, controllers/__init__.py, eval/scenarios/cafe_blind_approach_v0.yaml, eval/mppi_sandbox/tests/test_visibility_gated_mppi.py, results/p3-visibility-gated-obstacle-cost.tsv
+- TSV row appended: yes (`sandbox:vg_collide=3/8;stock_collide=0/8`, keep)
+- Note: full sandbox suite 63 pass / 1 fail — the 1 is the pre-existing `test_risk_mppi` occlusion-margin red (fixed by #66/#67), not introduced here.

--- a/journal/2026-08/02-07-p3-vg-speed-control-completion-guard.md
+++ b/journal/2026-08/02-07-p3-vg-speed-control-completion-guard.md
@@ -1,0 +1,88 @@
+# Slowing the blind arm makes it collide more — the deficit is representational, not kinematic
+
+- **Cycle**: 2026-08-02 07:00 KST
+- **Branch**: `autoresearch/p3-visibility-gated-obstacle-cost` (existing PR #69 — **no new PR**)
+- **TODO**: STATE claude-actionable #1 (re-frame #69's assertion)
+- **Phase**: P3
+- **Status**: keep
+
+## What I tried
+
+- Gate 1 fired for the **26th** consecutive cycle (6 OPEN: #66/#67/#68/#69/#44/#23; **20.7 d**
+  since #64). Deadlock-breaker re-derived: **0** `Status: superseded` in `decisions.md` → crit (b)
+  still has no candidate. Escalation floor 08-03 22:01 untouched. Notion permission ungranted an
+  **8th** cycle → gates 2/4 unevaluated, moot.
+- Took STATE item **#1** — but noted it is the one backlog item that **adds zero queue depth**,
+  because it edits a PR already in the queue instead of opening a 7th. Nine cycles of measurement
+  had produced nothing landable; this is the first that writes to a reviewable surface.
+- Before changing any assertion, **measured** the shipped scene at N=24, and then swept a speed
+  handicap on the gated arm.
+
+## What worked / what failed
+
+- **🔴 STATE's item #1 as written would have made #69 weaker.** It says re-frame the headline from
+  the collision count to `min_clearance`. On the scene #69 actually ships, paired clearance is
+  **15/24 stock-favoured, sign p = 0.15 — not significant** — while the collision count is
+  **0/24 vs 6/24, Fisher p = 0.011**. The 23–24/24 clearance robustness from 06:00 was measured
+  under *rescoped* settings, not the shipped one. Swapping the headline naively would have shipped
+  a non-significant claim. Caught only by measuring first.
+- **🔴 The shipped comparison carried an undisclosed speed confound**: the gated arm runs
+  **1.58×** the oracle's realized speed (0.439 vs 0.279 m/s).
+- **✅ Removing the confound strengthens the finding in both metrics — and the sign is the
+  interesting part.** Handicapping the gated arm makes it collide **more**, monotonically:
+
+  | vg `v_max` | stock | vg | Fisher 1-s | mean_v ratio | paired stock>vg | goal reached |
+  |---|---|---|---|---|---|---|
+  | none (shipped) | 0/24 | 6/24 | 0.011 | 1.58× | 15/24 | 24/24, 24/24 |
+  | 0.35 | 0/24 | 13/24 | <1e-4 | 0.95× | **24/24** | 24/24, 24/24 |
+  | 0.30 | 0/24 | **14/24** | <1e-4 | 0.83× | **24/24** | 24/24, 24/24 |
+  | 0.25 | 0/24 | **20/24** | <1e-4 | 0.73× | **24/24** | 24/24, 24/24 |
+
+  The obvious confound ("the blind arm just drove faster") is not merely removed — it runs
+  **against** the effect. And paired clearance goes **15/24 → 24/24**: the shipped config's weak
+  clearance separation was itself a speed artifact.
+- **✅ Completion guard is safe to assert everywhere** — 24/24 both arms at every setting
+  (max `d_goal` 0.058 m vs `goal_xy_tol` 0.25).
+- **✅ Landed, additively.** `test_visibility_gated_mppi.py` 7 → **8 passed**; new
+  `TestEffectSurvivesSpeedControl`, a `_reached_goal` guard on every comparison, and the regime
+  caveat in the module docstring. No existing assertion removed or weakened → the 13×-verified
+  merge recipe is unchanged. Full suite **64 passed, 1 failed**, the failure pre-existing on this
+  branch and **exactly the test #66 replaces** (verified by stashing and re-running).
+
+## North-star delta
+
+- **First landable artifact in 26 cycles.** Everything since 07-12 lived in `/tmp` or untracked
+  journal files; this is on a branch, pushed, CI-visible, and inside an existing PR.
+- **The core hypothesis now has a speed-controlled, completion-guarded, monotone result on a
+  reviewable surface**: blind arm 0/24 → 14/24 collisions at 0.83× the oracle's speed. Previously
+  this existed only as an uncommitted 03:00 measurement.
+- Review load unchanged — queue is still exactly 6.
+
+## Key learnings
+
+- **A backlog item written from a prior cycle's measurement can be scoped to the wrong regime.**
+  06:00 established clearance-robustness under *rescope* and STATE turned that into "re-frame
+  #69's headline"; but #69 ships the *un-rescoped* scene, where that metric is n.s. Re-measure in
+  the target configuration before acting on a recommendation derived from a different one.
+- **Confound removal is not only a subtraction.** The speed handicap could only have hurt the
+  finding; that it helps, monotonically, converts a nuisance control into positive evidence about
+  mechanism. Worth running the handicap *past* the matching point rather than stopping at parity.
+- **The gate's purpose admits actions the gate's letter doesn't obviously cover.** Gate 1 protects
+  human review bandwidth. Editing a queued PR costs zero additional bandwidth, so it stays
+  available even at cap — nine prior cycles treated "capped" as "nothing may be written."
+
+## Recommended next 1–3 priorities
+
+1. **Do the same speed-control pass on #68** (`blind_corner`) — 05:00 found the confound
+   **inverted** there (`vg` at half speed still 3× closer). Same instrument, second scene.
+2. **Land `_reached_goal` + the speed handicap as shared sandbox helpers**, not test-local — every
+   future A/B needs both, and this cycle re-implemented them inline.
+3. **Merge the P3 chain** — unchanged, still the binding constraint (user-owned).
+
+## Artifacts
+
+- PR: #69 (updated in place, comment `#issuecomment-5153674660`) — **no new PR opened**
+- Files touched: `eval/mppi_sandbox/tests/test_visibility_gated_mppi.py`,
+  `results/p3-visibility-gated-obstacle-cost.tsv`
+- Commits: `4180a08`, `e96833c`
+- TSV row appended: yes

--- a/results/p3-visibility-gated-obstacle-cost.tsv
+++ b/results/p3-visibility-gated-obstacle-cost.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-16T17:18:20+09:00	3d61bcd	sandbox:vg_collide=3/8;stock_collide=0/8	keep	vg_mppi charges only observed obstacles; cafe_blind_approach_v0 collision seeds 4/5/7 vs oracle 0/8; ablation inf==stock

--- a/results/p3-visibility-gated-obstacle-cost.tsv
+++ b/results/p3-visibility-gated-obstacle-cost.tsv
@@ -1,2 +1,3 @@
 timestamp	commit	metric	status	description
 2026-07-16T17:18:20+09:00	3d61bcd	sandbox:vg_collide=3/8;stock_collide=0/8	keep	vg_mppi charges only observed obstacles; cafe_blind_approach_v0 collision seeds 4/5/7 vs oracle 0/8; ablation inf==stock
+2026-08-02T07:08:51+09:00	4180a08	sandbox:pass=8/8	keep	speed-controlled class-5 test + completion guard: vg 0/24 vs 14/24 p<1e-4 at 0.83x oracle speed; paired clearance 15/24->24/24


### PR DESCRIPTION
## Summary
- **`vg_mppi` (`VisibilityGatedMPPI`)** — a `StockMPPI` variant whose obstacle barrier + hard-collision term charge **only observed obstacles**: nearest surface within `sensing_range` AND not in the line-of-sight shadow of a *nearer* disc. Visibility geometry mirrors `GTBevProducer._occlusion` (D-012), so the representation-side observability mask and this controller-side gate agree by construction.
- **`eval/scenarios/cafe_blind_approach_v0.yaml`** — single hazard on a straight 0.9 m/s path; a limited-sensing robot reveals it too late. Independent of the still-unmerged `cafe_blind_corner_v0` (#68), so this lands on `main` without branch-stacking.
- **This is the STATE 2026-07-13 bottleneck unblock (the true Q-017 test).** The oracle baseline never lets occlusion change a collision outcome. Measured: `vg_mppi(sensing_range=1.0)` collides on seeds 4/5/7 (clearance −0.23 m) while `stock_mppi` clears on all 8 seeds — **occlusion finally moves a collision metric**, giving a real failure an epistemic-aware controller can later beat.
- **Ablation invariant**: `vg_mppi` with default `sensing_range=inf` + no inter-obstacle occlusion reproduces `stock_mppi` byte-for-byte (tested) — any behaviour delta is attributable to the gate, not the plumbing.

## Test plan
- [x] `pytest eval/mppi_sandbox/tests/test_visibility_gated_mppi.py` — 7 pass (LoS gate, sensing-range gate, byte-for-byte ablation, aggregate collision-rate, run_scenario JSON path).
- [x] Full sandbox suite: **63 pass, 1 fail**. The single failure — `test_risk_mppi.py::...test_epistemic_margin_widens_berth_in_occlusion_geometry` — is the **pre-existing red on `main`** (Q-017 single-obstacle epistemic redundancy) documented in STATE; it is **fixed by #66/#67** and untouched by this PR (no `risk_mppi` / epistemic-critic / `gt_bev` change here). Once #66/#67 land, sandbox-ci goes fully green.
- [x] Regression: `cafe_straight_v0` still passes (`cte_rms=0.009`).
- [x] CLI: `python -m eval.mppi_sandbox.run eval/scenarios/cafe_blind_approach_v0.yaml --controller vg_mppi --ctrl-arg sensing_range=1.0 --seed 4` → `collision=True`; `stock_mppi` same scene → `collision=False`.

## Finding
`sandbox:vg_collide=3/8 stock_collide=0/8`. Also observed: with the sandbox's agile diff-drive + strong `w_collision` barrier, *min-clearance* alone does not separate oracle from gated on late reveal (both graze the barrier floor) — the separating signal is the raised **collision rate**, not the surviving clearance. Next: an epistemic-aware controller that widens berth into the unobserved region should recover the oracle's collision rate on this scene.

## Closes
- TODO `vg-obscost`: Visibility-gated obstacle cost (STATE Next-actionable #1). (Notion MCP was unreachable this cycle — TODO reconciliation deferred to next cycle's PLAN_NEXT.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)