### PR TITLE
[auto] P5 seed-sweep aggregator: collision/near-miss rate over seeds

### DIFF
--- a/eval/mppi_sandbox/seed_sweep.py
+++ b/eval/mppi_sandbox/seed_sweep.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Rate-over-seeds aggregator: run one (scenario, controller) across N seeds and
+report **collision / near-miss / pass rate**, not a single-seed clearance number.
+
+Motivation (STATE 2026-07-16, cycle p3-visibility-gated-obstacle-cost): on the
+sandbox's agile diff-drive plant with a strong `w_collision` barrier, the
+single-run **min-clearance saturates at the barrier floor** — it does *not*
+separate an oracle controller from an epistemic-blind one on a late-reveal
+occlusion scene. The signal that *does* separate them is stochastic: over a seed
+sweep the blind controller collides on some fraction of seeds while the oracle
+clears all of them (e.g. `vg_mppi` 3/8 vs `stock_mppi` 0/8 on
+`cafe_blind_approach_v0`). This module makes that fraction a first-class metric
+so P5's occlusion axis can score **rate over seeds** rather than surviving
+clearance.
+
+Schema is aggregation-only: it reuses `run_scenario`'s per-seed result verbatim
+and derives rates from the `min_obstacle_clearance` / `pass` fields — it adds no
+new simulation behavior, so a single-seed sweep reproduces `run_scenario`
+numbers exactly.
+
+CLI:
+    python -m eval.mppi_sandbox.seed_sweep eval/scenarios/cafe_straight_v0.yaml \
+        --controller stock_mppi --seeds 8 --near-miss-m 0.10 \
+        --run-id straight-stock-sweep --out-dir runs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .run import run_scenario
+
+# Default near-miss band: a positive clearance strictly below this many metres is
+# a "near miss" (did not collide, but grazed inside the safety margin). 0.10 m is
+# one third of the r=0.3 footprint — tunable per scenario acceptance later.
+DEFAULT_NEAR_MISS_M = 0.10
+
+
+def _classify(clearance: float, near_miss_m: float) -> str:
+    """collision (<0) / near_miss (0 ≤ c < near_miss_m) / safe (≥ near_miss_m)."""
+    if clearance < 0.0:
+        return "collision"
+    if clearance < near_miss_m:
+        return "near_miss"
+    return "safe"
+
+
+def seed_sweep(scenario_path: str | Path, *, controller: str = "stock_mppi",
+               seeds=range(8), near_miss_m: float = DEFAULT_NEAR_MISS_M,
+               run_id: str | None = None, out_dir: str | Path | None = None,
+               **controller_kwargs) -> dict:
+    """Run `controller` on `scenario_path` once per seed; aggregate outcome rates.
+
+    Returns a dict with per-seed rows and the sweep-level rates. `seeds` may be
+    any iterable of ints (e.g. `range(8)` or `[0, 3, 7]`). Rates are fractions in
+    [0, 1] over the number of seeds actually run.
+    """
+    seeds = [int(s) for s in seeds]
+    if not seeds:
+        raise ValueError("seed_sweep needs at least one seed")
+    if near_miss_m < 0.0:
+        raise ValueError("near_miss_m must be non-negative")
+
+    per_seed = []
+    for s in seeds:
+        r = run_scenario(scenario_path, controller=controller, seed=s,
+                         run_id=None, out_dir=None, **controller_kwargs)
+        clearance = r["min_obstacle_clearance"]
+        per_seed.append({
+            "seed": s,
+            "min_obstacle_clearance": clearance,
+            "collision": r["collision"],
+            "pass": r["pass"],
+            "outcome": _classify(clearance, near_miss_m),
+        })
+
+    n = len(per_seed)
+    n_collision = sum(1 for p in per_seed if p["outcome"] == "collision")
+    n_near_miss = sum(1 for p in per_seed if p["outcome"] == "near_miss")
+    # `pass` is None for scenarios with no hard acceptance checks; count only
+    # explicit True so pass_rate stays meaningful (None → not a pass).
+    n_pass = sum(1 for p in per_seed if p["pass"] is True)
+    finite_clear = [p["min_obstacle_clearance"] for p in per_seed]
+
+    result = {
+        "run_id": run_id or f"{Path(scenario_path).stem}-{controller}-sweep",
+        "started_at": datetime.now(timezone.utc).astimezone().isoformat(),
+        "backend": "mppi_sandbox",
+        "kind": "seed_sweep",
+        "scenario": str(scenario_path),
+        "controller": controller,
+        "controller_kwargs": controller_kwargs,
+        "seeds": seeds,
+        "n_seeds": n,
+        "near_miss_m": near_miss_m,
+        "collision_rate": n_collision / n,
+        "near_miss_rate": n_near_miss / n,
+        # unsafe = collided OR grazed: the headline occlusion-sensitivity number.
+        "unsafe_rate": (n_collision + n_near_miss) / n,
+        "pass_rate": n_pass / n,
+        "clearance_min": min(finite_clear),
+        "clearance_mean": sum(finite_clear) / n,
+        "per_seed": per_seed,
+    }
+    if out_dir is not None:
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / f"{result['run_id']}.json").write_text(
+            json.dumps(result, indent=2) + "\n")
+    return result
+
+
+def _parse_seeds(spec: str) -> list[int]:
+    """`8` → range(8); `0,3,7` → those seeds; `2-5` → 2..5 inclusive."""
+    spec = spec.strip()
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x.strip() != ""]
+    if "-" in spec:
+        lo, hi = spec.split("-", 1)
+        return list(range(int(lo), int(hi) + 1))
+    return list(range(int(spec)))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("scenario", help="path to eval/scenarios/*.yaml")
+    ap.add_argument("--controller", default="stock_mppi")
+    ap.add_argument("--seeds", default="8",
+                    help="count (8), list (0,3,7), or range (2-5)")
+    ap.add_argument("--near-miss-m", type=float, default=DEFAULT_NEAR_MISS_M)
+    ap.add_argument("--run-id", default=None)
+    ap.add_argument("--out-dir", default="runs")
+    ap.add_argument("--ctrl-arg", action="append", default=[],
+                    metavar="KEY=VALUE",
+                    help="controller kwarg, e.g. --ctrl-arg w_risk=15")
+    args = ap.parse_args(argv)
+    kwargs = {}
+    for pair in args.ctrl_arg:
+        key, value = pair.split("=", 1)
+        try:
+            kwargs[key] = float(value)
+        except ValueError:
+            kwargs[key] = value
+    result = seed_sweep(args.scenario, controller=args.controller,
+                        seeds=_parse_seeds(args.seeds),
+                        near_miss_m=args.near_miss_m,
+                        run_id=args.run_id, out_dir=args.out_dir, **kwargs)
+    # Print the aggregate without the (potentially long) per-seed block.
+    head = {k: v for k, v in result.items() if k != "per_seed"}
+    print(json.dumps(head, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/mppi_sandbox/tests/test_seed_sweep.py
+++ b/eval/mppi_sandbox/tests/test_seed_sweep.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Tests for the rate-over-seeds aggregator (eval/mppi_sandbox/seed_sweep.py).
+
+Two layers:
+1. Pure aggregation logic (`_classify`, rate arithmetic) — driven with a
+   monkeypatched `run_scenario` so the outcome mix is exact and fast.
+2. A thin end-to-end smoke over the real sandbox on `cafe_straight_v0` to prove
+   the aggregator wires into `run_scenario` and that a single-seed sweep matches
+   the underlying per-seed numbers (the "adds search, not behavior" contract).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eval.mppi_sandbox import seed_sweep as ss
+from eval.mppi_sandbox.run import run_scenario
+
+STRAIGHT = "eval/scenarios/cafe_straight_v0.yaml"
+
+
+# ---- layer 1: aggregation logic with a fake run_scenario -------------------
+
+def _fake_runs(clearances):
+    """Build a run_scenario stub that returns the given clearance per call."""
+    calls = {"i": 0}
+
+    def fake(scenario_path, *, controller, seed, run_id, out_dir, **kw):
+        c = clearances[calls["i"]]
+        calls["i"] += 1
+        return {
+            "min_obstacle_clearance": c,
+            "collision": bool(c < 0.0),
+            "pass": bool(c >= 0.0),
+            "seed": seed,
+        }
+    return fake
+
+
+def test_classify_bands():
+    assert ss._classify(-0.01, 0.10) == "collision"
+    assert ss._classify(0.0, 0.10) == "near_miss"
+    assert ss._classify(0.05, 0.10) == "near_miss"
+    assert ss._classify(0.10, 0.10) == "safe"
+    assert ss._classify(1.0, 0.10) == "safe"
+
+
+def test_rates_count_correctly(monkeypatch):
+    # 8 seeds: 2 collide, 2 near-miss, 4 safe.
+    clearances = [-0.2, -0.1, 0.05, 0.09, 0.5, 0.5, 0.5, 0.5]
+    monkeypatch.setattr(ss, "run_scenario", _fake_runs(clearances))
+    r = ss.seed_sweep(STRAIGHT, controller="stock_mppi",
+                      seeds=range(8), near_miss_m=0.10)
+    assert r["n_seeds"] == 8
+    assert r["collision_rate"] == pytest.approx(2 / 8)
+    assert r["near_miss_rate"] == pytest.approx(2 / 8)
+    assert r["unsafe_rate"] == pytest.approx(4 / 8)
+    assert r["pass_rate"] == pytest.approx(6 / 8)   # the 6 non-colliding runs
+    assert r["clearance_min"] == pytest.approx(-0.2)
+
+
+def test_all_rates_in_unit_interval(monkeypatch):
+    clearances = [-0.2, 0.05, 0.5]
+    monkeypatch.setattr(ss, "run_scenario", _fake_runs(clearances))
+    r = ss.seed_sweep(STRAIGHT, seeds=range(3))
+    for key in ("collision_rate", "near_miss_rate", "unsafe_rate", "pass_rate"):
+        assert 0.0 <= r[key] <= 1.0
+
+
+def test_near_miss_threshold_monotonic(monkeypatch):
+    # A wider near-miss band can only *increase* (never decrease) near_miss_rate.
+    clearances = [0.05, 0.15, 0.25, 0.5]
+
+    def sweep(nm):
+        monkeypatch.setattr(ss, "run_scenario", _fake_runs(list(clearances)))
+        return ss.seed_sweep(STRAIGHT, seeds=range(4), near_miss_m=nm)
+
+    rates = [sweep(nm)["near_miss_rate"] for nm in (0.10, 0.20, 0.30)]
+    assert rates == sorted(rates)
+    assert rates[0] == pytest.approx(1 / 4)   # only 0.05
+    assert rates[2] == pytest.approx(3 / 4)   # 0.05, 0.15, 0.25
+
+
+def test_empty_seeds_rejected():
+    with pytest.raises(ValueError):
+        ss.seed_sweep(STRAIGHT, seeds=[])
+
+
+def test_negative_near_miss_rejected():
+    with pytest.raises(ValueError):
+        ss.seed_sweep(STRAIGHT, seeds=range(2), near_miss_m=-0.1)
+
+
+def test_parse_seeds():
+    assert ss._parse_seeds("8") == list(range(8))
+    assert ss._parse_seeds("0,3,7") == [0, 3, 7]
+    assert ss._parse_seeds("2-5") == [2, 3, 4, 5]
+
+
+# ---- layer 2: real-sandbox smoke -------------------------------------------
+
+def test_single_seed_sweep_matches_run_scenario():
+    """A 1-seed sweep must reproduce the underlying run_scenario clearance —
+    the aggregator adds search, not simulation behavior."""
+    ref = run_scenario(STRAIGHT, controller="stock_mppi", seed=0, out_dir=None)
+    r = ss.seed_sweep(STRAIGHT, controller="stock_mppi", seeds=[0])
+    assert r["n_seeds"] == 1
+    assert r["clearance_min"] == pytest.approx(ref["min_obstacle_clearance"])
+    assert r["per_seed"][0]["collision"] == ref["collision"]
+
+
+def test_multi_seed_sweep_writes_json(tmp_path):
+    r = ss.seed_sweep(STRAIGHT, controller="stock_mppi", seeds=range(3),
+                      run_id="unit-straight-sweep", out_dir=tmp_path)
+    out = Path(tmp_path) / "unit-straight-sweep.json"
+    assert out.exists()
+    assert r["n_seeds"] == 3
+    assert len(r["per_seed"]) == 3
+    # cafe_straight has no obstacles → clearance is +inf, zero unsafe.
+    assert r["collision_rate"] == 0.0

--- a/results/p5-collision-rate-over-seeds-aggregator.tsv
+++ b/results/p5-collision-rate-over-seeds-aggregator.tsv
@@ -1,0 +1,2 @@
+timestamp	commit	metric	status	description
+2026-07-17T10:05:58+09:00	11d347e	sandbox:seed_sweep_tests=9/9	in_progress	rate-over-seeds aggregator: collision/near_miss/unsafe/pass rate over seeds; head_on stock unsafe=4/4 collide=0/4 (min-clearance saturates, rate separates)


### PR DESCRIPTION
## Summary
- Adds `eval/mppi_sandbox/seed_sweep.py`: runs one `(scenario, controller)` across N seeds and reports **collision_rate / near_miss_rate / unsafe_rate / pass_rate** instead of a single-seed `min_obstacle_clearance`.
- Motivation (STATE 2026-07-16, cycle `p3-visibility-gated-obstacle-cost`): on the agile diff-drive plant with a strong `w_collision` barrier, **min-clearance saturates at the barrier floor** and cannot separate an oracle from an epistemic-blind controller on a late-reveal occlusion scene. The separating signal is stochastic — the seed-wise collision/near-miss fraction (e.g. `vg_mppi` 3/8 vs `stock_mppi` 0/8). This makes that fraction a first-class P5 occlusion-axis metric.
- **Aggregation-only**: reuses `run_scenario` verbatim and derives rates from its `min_obstacle_clearance`/`pass` fields — a 1-seed sweep reproduces `run_scenario` numbers (adds search, not simulation behavior). CLI: `python -m eval.mppi_sandbox.seed_sweep <scenario> --controller stock_mppi --seeds 8 --near-miss-m 0.10`.

## Test plan
- [x] 9 new tests green (`eval/mppi_sandbox/tests/test_seed_sweep.py`): band classification, rate arithmetic, near-miss monotonicity, seed-spec parsing, empty/negative guards, single-seed==run_scenario contract, JSON writeout.
- [x] Full sandbox suite: 65 pass + 1 **pre-existing** red (`test_epistemic_margin_widens_berth_in_occlusion_geometry`, fixed by unmerged #66 — not introduced here; this PR does not touch `risk_mppi`).
- [x] Live smoke on `cafe_head_on_v0`: stock grazes every seed → `unsafe_rate=1.0, near_miss_rate=1.0, collision_rate=0.0` (min-clearance ~0.003 m saturates; rate separates).

## Closes
- STATE next-actionable #3: P5 occlusion metric = collision/near-miss rate over seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)